### PR TITLE
Upgrade trino from 423 to 435 and fix import statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
         <!-- App specific properties -->
-        <trino.version>430</trino.version>
+        <trino.version>435</trino.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
         <!-- App specific properties -->
-        <trino.version>424</trino.version>
+        <trino.version>430</trino.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
         <!-- App specific properties -->
-        <trino.version>423</trino.version>
+        <trino.version>424</trino.version>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +53,11 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-parser</artifactId>
+            <version>${trino.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-cli</artifactId>
             <version>${trino.version}</version>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/yuokada/subcommand/Format.java
+++ b/src/main/java/io/github/yuokada/subcommand/Format.java
@@ -6,7 +6,6 @@ import static io.trino.sql.SqlFormatter.formatSql;
 import com.google.common.collect.ImmutableSet;
 import io.github.yuokada.EntryCommand;
 import io.trino.cli.lexer.StatementSplitter;
-import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Statement;
 import java.io.BufferedReader;
@@ -76,11 +75,10 @@ public class Format implements Callable<Integer> {
   }
 
   private static String format(String sql) {
-    ParsingOptions parsingOptions = new ParsingOptions();
-    Statement statement = sqlParser.createStatement(sql, parsingOptions);
+    Statement statement = sqlParser.createStatement(sql);
     String formattedSql = formatSql(statement);
     checkState(
-        statement.equals(sqlParser.createStatement(formattedSql, parsingOptions)),
+        statement.equals(sqlParser.createStatement(formattedSql)),
         "Formatted SQL is different than original");
     return formattedSql;
   }

--- a/src/main/java/io/github/yuokada/subcommand/Format.java
+++ b/src/main/java/io/github/yuokada/subcommand/Format.java
@@ -5,9 +5,9 @@ import static io.trino.sql.SqlFormatter.formatSql;
 
 import com.google.common.collect.ImmutableSet;
 import io.github.yuokada.EntryCommand;
+import io.trino.cli.lexer.StatementSplitter;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
-import io.trino.sql.parser.StatementSplitter;
 import io.trino.sql.tree.Statement;
 import java.io.BufferedReader;
 import java.io.IOException;


### PR DESCRIPTION
## Overview

- Upgrade trino from 423 and fix import statements
  - https://github.com/trinodb/trino/compare/423...424
- Remove unused ParsingOptions
  - https://github.com/trinodb/trino/compare/427...428
   https://github.com/trinodb/trino/commit/57c5c324e3ac1f0c6d9b2d35434986baeae41e32
- Java 17 is supported until Trino 435.
    https://github.com/trinodb/trino/commit/09ef5b5aa240a3768cc1cb2576e9d06a23cbd7a1
    https://github.com/trinodb/trino/blob/5c2b05910cdad7862fd50929320c9d7b7ed60c24/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java