### PR TITLE
Reject multiple statements in analyze subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ UPDATE_GOLDEN=true ./mvnw test -Dtest=GoldenFormatTest
 
 ## `analyze` subcommand
 
-Analyzes one or more SQL statements and reports catalogs, tables, functions, joins,
+Analyzes exactly one SQL statement and reports catalogs, tables, functions, joins,
 CTEs, and lint findings.
 
 ### Usage
@@ -144,10 +144,10 @@ analyze [options] [<file>]
 | Option | Default | Description |
 |---|---|---|
 | `<file>` | stdin | SQL file to analyze. Reads from stdin when omitted. |
-| `--format <fmt>` | `text` | Output format: `text` or `json` (NDJSON — one object per statement). |
+| `--format <fmt>` | `text` | Output format: `text` or `json` (single object for the single query). |
 | `--details <level>` | `basic` | Detail level: `basic` (catalogs only) or `full` (all fields + lint). |
 | `--output <path>` | stdout | Write output to this file instead of stdout. |
-| `--show-ast` | false | Print the AST after each statement. |
+| `--show-ast` | false | Print the AST for the query. |
 | `--ast-limit <n>` | `10000` | Maximum characters for the embedded AST in JSON output. |
 | `--catalog <name>` | — | Default catalog for partially qualified names (`schema.table`). |
 | `--schema <name>` | — | Default schema for unqualified names (`table`), requires `--catalog`. |
@@ -182,6 +182,14 @@ analyze --format json --details full query.sql
 
 ```json
 {"queryType":"Query","catalogs":["catalog1"],"tables":["catalog1.s.orders"],"usesSelectStar":true,"ctes":[],"joins":[],"functionsScalar":[],"functionsAggregate":[],"functionsWindow":[],"writeTargets":[],"findings":[{"ruleId":"W001","severity":"WARNING","message":"SELECT * detected; prefer explicit column list"}],"hasLimit":false}
+```
+
+### Multiple statements are rejected
+
+```bash
+analyze multi.sql
+# stderr: analyze supports exactly one query; found multiple statements
+# exit code: 1
 ```
 
 ### Catalog / schema defaults
@@ -224,7 +232,7 @@ java -jar ... --quiet format --check query.sql
 | Code | Meaning |
 |---|---|
 | `0` | Success. |
-| `1` | WARNING — `--check` found statements that need reformatting. |
+| `1` | WARNING/validation failure — `--check` found statements that need reformatting, or `analyze` received multiple statements. |
 | `2` | ERROR — parse error, missing file, or invalid option value. |
 | `3` | EXCEPTION — unexpected runtime error. |
 

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -9,6 +9,8 @@ import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.output.TextAnalysisPrinter;
 import io.github.yuokada.subcommand.util.SqlInput;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
@@ -17,6 +19,9 @@ import picocli.CommandLine.ParentCommand;
 
 @CommandLine.Command(name = "analyze", description = "Analyze SQL query")
 public class Analyze implements Callable<Integer> {
+    private static final String MULTIPLE_STATEMENTS_ERROR_MESSAGE =
+        "analyze supports exactly one query; found multiple statements";
+    private static final int MULTIPLE_STATEMENTS_EXIT_CODE = 1;
 
     /**
      * The parent command.
@@ -86,26 +91,36 @@ public class Analyze implements Callable<Integer> {
 
     @Override
     public Integer call() throws IOException {
+        List<String> statements = collectStatements();
+        if (statements.size() > 1) {
+            System.err.println(MULTIPLE_STATEMENTS_ERROR_MESSAGE);
+            return MULTIPLE_STATEMENTS_EXIT_CODE;
+        }
+
+        if (statements.isEmpty()) {
+            return ExitCode.OK;
+        }
+
+        String statement = statements.get(0);
         try (OutputEmitter emitter = new OutputEmitter(outputPath);
             AnalysisPrinter printer = isJsonFormat()
                 ? new JsonAnalysisPrinter(emitter, isBasicDetails(), showAst, astLimit)
                 : new TextAnalysisPrinter(emitter, isFullDetails(), showAst)) {
-
-            if (!sqlFile.isEmpty()) {
-                SqlInput.forEachStatementFromFile(sqlFile, stmt -> {
-                    QueryAnalysisResult result =
-                        QueryAnalyzer.analyze(stmt, defaultCatalog, defaultSchema);
-                    printer.printStatement(result, null, stmt);
-                });
-            } else {
-                SqlInput.forEachStatementFromStdin((idx, stmt) -> {
-                    QueryAnalysisResult result =
-                        QueryAnalyzer.analyze(stmt, defaultCatalog, defaultSchema);
-                    printer.printStatement(result, idx, stmt);
-                });
-            }
+            QueryAnalysisResult result =
+                QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema);
+            printer.printStatement(result, null, statement);
         }
         return ExitCode.OK;
+    }
+
+    private List<String> collectStatements() throws IOException {
+        List<String> statements = new ArrayList<>();
+        if (!sqlFile.isEmpty()) {
+            SqlInput.forEachStatementFromFile(sqlFile, statements::add);
+            return statements;
+        }
+        SqlInput.forEachStatementFromStdin((idx, stmt) -> statements.add(stmt));
+        return statements;
     }
 
     /**

--- a/src/test/java/io/github/yuokada/EntryCommandTest.java
+++ b/src/test/java/io/github/yuokada/EntryCommandTest.java
@@ -17,17 +17,21 @@ import picocli.CommandLine;
 class EntryCommandTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
     private final java.io.InputStream originalIn = System.in;
 
     @BeforeEach
     void setUpStreams() {
         System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
     }
 
     @AfterEach
     void restoreStreams() {
         System.setOut(originalOut);
+        System.setErr(originalErr);
         System.setIn(originalIn);
     }
 
@@ -110,13 +114,24 @@ class EntryCommandTest {
 
         int exit = new CommandLine(new EntryCommand()).execute("analyze");
 
-        String expected = """
-            =========================
-            Catalogs of Query No 1: [catalog1]
-            =========================
-            No catalogs found.
-            """.trim();
-        assertEquals(0, exit);
-        assertEquals(expected, outContent.toString().trim());
+        assertEquals(1, exit);
+        assertEquals("", outContent.toString().trim());
+        assertEquals(
+            "analyze supports exactly one query; found multiple statements",
+            errContent.toString().trim());
+    }
+
+    @Test
+    void analyze_multipleQueriesFromFile_viaCommandLine(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("analyze_multi.sql");
+        Files.writeString(sqlFile, "SELECT * FROM catalog1.schema.tbl1; SELECT 1;");
+
+        int exit = new CommandLine(new EntryCommand()).execute("analyze", sqlFile.toString());
+
+        assertEquals(1, exit);
+        assertEquals("", outContent.toString().trim());
+        assertEquals(
+            "analyze supports exactly one query; found multiple statements",
+            errContent.toString().trim());
     }
 }

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeJsonAstTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeJsonAstTest.java
@@ -22,22 +22,26 @@ import org.junit.jupiter.api.io.TempDir;
 class AnalyzeJsonAstTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
     private final java.io.InputStream originalIn = System.in;
 
     @BeforeEach
     public void setUpStreams() {
         System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
     }
 
     @AfterEach
     public void restoreStreams() {
         System.setOut(originalOut);
+        System.setErr(originalErr);
         System.setIn(originalIn);
     }
 
     @Test
-    void testJsonOutputWithTwoStatements(@TempDir Path tempDir) throws IOException {
+    void testJsonOutputWithTwoStatements_returnsError(@TempDir Path tempDir) throws IOException {
         Path sqlFile = tempDir.resolve("two.sql");
         String sql = "SELECT 1; SELECT * FROM catalog1.s.t;";
         Files.writeString(sqlFile, sql);
@@ -45,13 +49,13 @@ class AnalyzeJsonAstTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sqlFile.toString());
         analyze.setFormat("json");
-        analyze.call();
+        int exitCode = analyze.call();
 
-        String out = outContent.toString(StandardCharsets.UTF_8);
-        String[] lines = out.strip().split("\n");
-        assertEquals(2, lines.length);
-        assertTrue(lines[0].contains("\"queryType\""));
-        assertTrue(lines[1].contains("\"catalogs\""));
+        assertEquals(1, exitCode);
+        assertEquals("", outContent.toString(StandardCharsets.UTF_8).strip());
+        assertEquals(
+            "analyze supports exactly one query; found multiple statements",
+            errContent.toString(StandardCharsets.UTF_8).strip());
     }
 
     @Test
@@ -84,7 +88,7 @@ class AnalyzeJsonAstTest {
         analyze.call();
 
         String out = outContent.toString(StandardCharsets.UTF_8);
-        assertTrue(out.contains("Catalogs of Query No") || out.contains("Catalogs:"));
+        assertTrue(out.contains("Catalogs:"));
         assertTrue(out.contains("AST:"));
     }
 

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeTest.java
@@ -16,20 +16,24 @@ import org.junit.jupiter.api.io.TempDir;
 class AnalyzeTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
 
     @BeforeEach
     public void setUpStreams() {
         System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
     }
 
     @AfterEach
     public void restoreStreams() {
         System.setOut(originalOut);
+        System.setErr(originalErr);
     }
 
     @Test
-    void testCallWithFile(@TempDir Path tempDir) throws IOException {
+    void testCallWithFile_multipleQueries_returnsError(@TempDir Path tempDir) throws IOException {
         Path sqlFile = tempDir.resolve("test.sql");
         String sql = "SELECT * FROM catalog1.schema.tbl1; SELECT * FROM catalog2.schema.tbl2;";
         Files.writeString(sqlFile, sql);
@@ -42,15 +46,13 @@ class AnalyzeTest {
         } catch (ReflectiveOperationException e) {
             throw new IOException(e);
         }
-        analyze.call();
+        int exitCode = analyze.call();
 
-        String expectedOutput = """
-            =========================
-            Catalogs: [catalog1]
-            =========================
-            Catalogs: [catalog2]
-            """.trim();
-        assertEquals(expectedOutput, outContent.toString().trim());
+        assertEquals(1, exitCode);
+        assertEquals("", outContent.toString().trim());
+        assertEquals(
+            "analyze supports exactly one query; found multiple statements",
+            errContent.toString().trim());
     }
 
     @Test

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsTest.java
@@ -32,8 +32,8 @@ class AnalyzeTextDetailsTest {
 
     @Test
     void testTextFullDetailsPrintsExtendedInfo(@TempDir Path tempDir) throws IOException {
-        Path sqlFile = tempDir.resolve("multi.sql");
-        String sql = "SELECT * FROM catalog1.s.t LIMIT 10; DELETE FROM catalog1.s.t WHERE id = 1;";
+        Path sqlFile = tempDir.resolve("single.sql");
+        String sql = "SELECT * FROM catalog1.s.t LIMIT 10;";
         Files.writeString(sqlFile, sql);
 
         Analyze analyze = new Analyze();
@@ -48,9 +48,6 @@ class AnalyzeTextDetailsTest {
         assertTrue(out.contains("Tables: [catalog1.s.t]"));
         assertTrue(out.contains("usesSelectStar=true"));
         assertTrue(out.contains("hasLimit=true"));
-        // Second statement assertions
-        assertTrue(out.contains("QueryType: Delete"));
-        assertTrue(out.contains("hasWhereOnDelete=true"));
     }
 
     @Test
@@ -106,4 +103,3 @@ class AnalyzeTextDetailsTest {
             "No W001 finding should appear for SELECT id: " + out);
     }
 }
-


### PR DESCRIPTION
## Summary
- make analyze accept exactly one statement
- return exit code 1 and print an error message to stderr when multiple statements are passed
- update tests for file/stdin multi-statement behavior and README docs

## Behavior change
When input contains multiple statements, analyze now fails with:
analyze supports exactly one query; found multiple statements

## Testing
- attempted: ./mvnw test -Dtest=AnalyzeTest,AnalyzeTextDetailsTest,AnalyzeJsonAstTest,EntryCommandTest
- could not run in this environment due to missing Java Runtime
