### PR TITLE
Stop publishing SNAPSHOT artifacts to GitHub

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,11 +6,6 @@ name: Maven Package
 
 # see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
-  pull_request:
-    branches:
-      - master
-  # release:
-  #   types: [created]
   push:
     tags:
       - v0.**
@@ -36,7 +31,12 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
+    - name: Detect project version
+      id: project-version
+      run: echo "value=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)" >> "$GITHUB_OUTPUT"
+
     - name: Publish to GitHub Packages Apache Maven
+      if: ${{ !contains(steps.project-version.outputs.value, 'SNAPSHOT') }}
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- remove `pull_request` trigger from `maven-publish.yml`
- keep publish workflow only on tag pushes
- add a guard to skip `mvn deploy` when `project.version` contains `SNAPSHOT`

## Why
This prevents publishing SNAPSHOT artifacts to GitHub Packages.
