### PR TITLE
Add --diff, Trino dialect tests, and CASE/JOIN/subquery golden tests

### DIFF
--- a/src/main/java/io/github/yuokada/core/UnifiedDiff.java
+++ b/src/main/java/io/github/yuokada/core/UnifiedDiff.java
@@ -1,0 +1,230 @@
+package io.github.yuokada.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Minimal unified-diff generator backed by a Longest Common Subsequence algorithm.
+ *
+ * <p>Produces standard unified-diff output ({@code ---}/{@code +++}/{@code @@} hunks)
+ * with optional ANSI colour (red for deletions, green for additions, cyan for hunk headers).
+ *
+ * <p>The LCS DP table is O(n × m) in time and space, which is acceptable for the SQL
+ * files this tool targets (typically a few hundred lines).
+ */
+public final class UnifiedDiff {
+
+    /** ANSI red — used for deleted lines and the {@code ---} header. */
+    private static final String ANSI_RED = "\033[31m";
+
+    /** ANSI green — used for inserted lines and the {@code +++} header. */
+    private static final String ANSI_GREEN = "\033[32m";
+
+    /** ANSI cyan — used for {@code @@} hunk headers. */
+    private static final String ANSI_CYAN = "\033[36m";
+
+    /** ANSI reset sequence. */
+    private static final String ANSI_RESET = "\033[0m";
+
+    private UnifiedDiff() {
+    }
+
+    /**
+     * Computes a unified diff between {@code original} and {@code revised} line lists.
+     *
+     * @param original     original lines
+     * @param revised      revised lines
+     * @param fromLabel    label shown on the {@code ---} header line
+     * @param toLabel      label shown on the {@code +++} header line
+     * @param contextLines number of unchanged context lines to show around each change
+     * @param colorize     when {@code true}, ANSI colour codes are emitted
+     * @return unified-diff string, or an empty string when there are no differences
+     */
+    public static String compute(
+        List<String> original,
+        List<String> revised,
+        String fromLabel,
+        String toLabel,
+        int contextLines,
+        boolean colorize) {
+
+        List<Edit> edits = buildEdits(original, revised);
+        List<int[]> ranges = buildHunkRanges(edits, contextLines);
+        if (ranges.isEmpty()) {
+            return "";
+        }
+
+        // Pre-compute 1-based original/revised line numbers for each edit position.
+        int[] origLineAt = new int[edits.size()];
+        int[] revLineAt = new int[edits.size()];
+        int ol = 1;
+        int rl = 1;
+        for (int i = 0; i < edits.size(); i++) {
+            origLineAt[i] = ol;
+            revLineAt[i] = rl;
+            int k = edits.get(i).kind;
+            if (k == 0) {
+                ol++;
+                rl++;
+            } else if (k == -1) {
+                ol++;
+            } else {
+                rl++;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String fromHeader = "--- " + fromLabel;
+        String toHeader = "+++ " + toLabel;
+        if (colorize) {
+            sb.append(ANSI_RED).append(fromHeader).append(ANSI_RESET).append('\n');
+            sb.append(ANSI_GREEN).append(toHeader).append(ANSI_RESET).append('\n');
+        } else {
+            sb.append(fromHeader).append('\n');
+            sb.append(toHeader).append('\n');
+        }
+
+        for (int[] range : ranges) {
+            int start = range[0];
+            int end = range[1];
+            List<Edit> hunk = edits.subList(start, end + 1);
+
+            int oStart = origLineAt[start];
+            int rStart = revLineAt[start];
+            int oCount = 0;
+            int rCount = 0;
+            for (Edit e : hunk) {
+                if (e.kind == 0 || e.kind == -1) {
+                    oCount++;
+                }
+                if (e.kind == 0 || e.kind == 1) {
+                    rCount++;
+                }
+            }
+
+            String hunkHeader =
+                "@@ -" + oStart + "," + oCount + " +" + rStart + "," + rCount + " @@";
+            if (colorize) {
+                sb.append(ANSI_CYAN).append(hunkHeader).append(ANSI_RESET).append('\n');
+            } else {
+                sb.append(hunkHeader).append('\n');
+            }
+
+            for (Edit e : hunk) {
+                String prefix = e.kind == -1 ? "-" : e.kind == 1 ? "+" : " ";
+                String line = prefix + e.text;
+                if (colorize && e.kind == -1) {
+                    sb.append(ANSI_RED).append(line).append(ANSI_RESET);
+                } else if (colorize && e.kind == 1) {
+                    sb.append(ANSI_GREEN).append(line).append(ANSI_RESET);
+                } else {
+                    sb.append(line);
+                }
+                sb.append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds hunk ranges as {@code [start, end]} index pairs into the edit list.
+     * Adjacent or overlapping ranges are merged.
+     *
+     * @param edits       full edit list
+     * @param ctx         number of context lines to include around each change
+     * @return list of {@code [start, end]} pairs
+     */
+    private static List<int[]> buildHunkRanges(List<Edit> edits, int ctx) {
+        List<Integer> changes = new ArrayList<>();
+        for (int i = 0; i < edits.size(); i++) {
+            if (edits.get(i).kind != 0) {
+                changes.add(i);
+            }
+        }
+        if (changes.isEmpty()) {
+            return List.of();
+        }
+        List<int[]> ranges = new ArrayList<>();
+        for (int ci : changes) {
+            int s = Math.max(0, ci - ctx);
+            int e = Math.min(edits.size() - 1, ci + ctx);
+            if (!ranges.isEmpty()) {
+                int[] last = ranges.get(ranges.size() - 1);
+                if (s <= last[1] + 1) {
+                    last[1] = Math.max(last[1], e);
+                    continue;
+                }
+            }
+            ranges.add(new int[]{s, e});
+        }
+        return ranges;
+    }
+
+    /**
+     * Builds a line-level edit list using the Longest Common Subsequence DP algorithm.
+     * Each {@link Edit} has kind {@code 0} (equal), {@code -1} (delete from original),
+     * or {@code +1} (insert into revised).
+     *
+     * @param a original lines
+     * @param b revised lines
+     * @return ordered list of edits describing the transformation from {@code a} to {@code b}
+     */
+    private static List<Edit> buildEdits(List<String> a, List<String> b) {
+        int n = a.size();
+        int m = b.size();
+        int[][] dp = new int[n + 1][m + 1];
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                if (a.get(i - 1).equals(b.get(j - 1))) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+        List<Edit> result = new ArrayList<>();
+        int i = n;
+        int j = m;
+        while (i > 0 || j > 0) {
+            if (i > 0 && j > 0 && a.get(i - 1).equals(b.get(j - 1))) {
+                result.add(new Edit(0, a.get(i - 1)));
+                i--;
+                j--;
+            } else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+                result.add(new Edit(1, b.get(j - 1)));
+                j--;
+            } else {
+                result.add(new Edit(-1, a.get(i - 1)));
+                i--;
+            }
+        }
+        Collections.reverse(result);
+        return result;
+    }
+
+    /**
+     * A single line-level edit operation.
+     */
+    private static final class Edit {
+
+        /**
+         * Edit kind: {@code 0} = equal, {@code -1} = delete, {@code +1} = insert.
+         */
+        final int kind;
+
+        /**
+         * The line text (without any diff prefix).
+         */
+        final String text;
+
+        /**
+         * @param kind edit kind
+         * @param text line text
+         */
+        Edit(int kind, String text) {
+            this.kind = kind;
+            this.text = text;
+        }
+    }
+}

--- a/src/main/java/io/github/yuokada/core/UnifiedDiff.java
+++ b/src/main/java/io/github/yuokada/core/UnifiedDiff.java
@@ -56,21 +56,21 @@ public final class UnifiedDiff {
         }
 
         // Pre-compute 1-based original/revised line numbers for each edit position.
-        int[] origLineAt = new int[edits.size()];
-        int[] revLineAt = new int[edits.size()];
-        int ol = 1;
-        int rl = 1;
+        int[] originalLineNumber = new int[edits.size()];
+        int[] revisedLineNumber = new int[edits.size()];
+        int originalLineCounter = 1;
+        int revisedLineCounter = 1;
         for (int i = 0; i < edits.size(); i++) {
-            origLineAt[i] = ol;
-            revLineAt[i] = rl;
+            originalLineNumber[i] = originalLineCounter;
+            revisedLineNumber[i] = revisedLineCounter;
             int k = edits.get(i).kind;
             if (k == 0) {
-                ol++;
-                rl++;
+                originalLineCounter++;
+                revisedLineCounter++;
             } else if (k == -1) {
-                ol++;
+                originalLineCounter++;
             } else {
-                rl++;
+                revisedLineCounter++;
             }
         }
 
@@ -90,21 +90,22 @@ public final class UnifiedDiff {
             int end = range[1];
             List<Edit> hunk = edits.subList(start, end + 1);
 
-            int oStart = origLineAt[start];
-            int rStart = revLineAt[start];
-            int oCount = 0;
-            int rCount = 0;
+            int originalStartLine = originalLineNumber[start];
+            int revisedStartLine = revisedLineNumber[start];
+            int originalLineCount = 0;
+            int revisedLineCount = 0;
             for (Edit e : hunk) {
                 if (e.kind == 0 || e.kind == -1) {
-                    oCount++;
+                    originalLineCount++;
                 }
                 if (e.kind == 0 || e.kind == 1) {
-                    rCount++;
+                    revisedLineCount++;
                 }
             }
 
             String hunkHeader =
-                "@@ -" + oStart + "," + oCount + " +" + rStart + "," + rCount + " @@";
+                "@@ -" + originalStartLine + "," + originalLineCount
+                    + " +" + revisedStartLine + "," + revisedLineCount + " @@";
             if (colorize) {
                 sb.append(ANSI_CYAN).append(hunkHeader).append(ANSI_RESET).append('\n');
             } else {
@@ -146,17 +147,17 @@ public final class UnifiedDiff {
             return List.of();
         }
         List<int[]> ranges = new ArrayList<>();
-        for (int ci : changes) {
-            int s = Math.max(0, ci - ctx);
-            int e = Math.min(edits.size() - 1, ci + ctx);
+        for (int changeIndex : changes) {
+            int startHunkIndex = Math.max(0, changeIndex - ctx);
+            int endHunkIndex = Math.min(edits.size() - 1, changeIndex + ctx);
             if (!ranges.isEmpty()) {
                 int[] last = ranges.get(ranges.size() - 1);
-                if (s <= last[1] + 1) {
-                    last[1] = Math.max(last[1], e);
+                if (startHunkIndex <= last[1] + 1) {
+                    last[1] = Math.max(last[1], endHunkIndex);
                     continue;
                 }
             }
-            ranges.add(new int[]{s, e});
+            ranges.add(new int[]{startHunkIndex, endHunkIndex});
         }
         return ranges;
     }
@@ -171,11 +172,11 @@ public final class UnifiedDiff {
      * @return ordered list of edits describing the transformation from {@code a} to {@code b}
      */
     private static List<Edit> buildEdits(List<String> a, List<String> b) {
-        int n = a.size();
-        int m = b.size();
-        int[][] dp = new int[n + 1][m + 1];
-        for (int i = 1; i <= n; i++) {
-            for (int j = 1; j <= m; j++) {
+        int originalSize = a.size();
+        int revisedSize = b.size();
+        int[][] dp = new int[originalSize + 1][revisedSize + 1];
+        for (int i = 1; i <= originalSize; i++) {
+            for (int j = 1; j <= revisedSize; j++) {
                 if (a.get(i - 1).equals(b.get(j - 1))) {
                     dp[i][j] = dp[i - 1][j - 1] + 1;
                 } else {
@@ -184,19 +185,22 @@ public final class UnifiedDiff {
             }
         }
         List<Edit> result = new ArrayList<>();
-        int i = n;
-        int j = m;
-        while (i > 0 || j > 0) {
-            if (i > 0 && j > 0 && a.get(i - 1).equals(b.get(j - 1))) {
-                result.add(new Edit(0, a.get(i - 1)));
-                i--;
-                j--;
-            } else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-                result.add(new Edit(1, b.get(j - 1)));
-                j--;
+        int originalIndex = originalSize;
+        int revisedIndex = revisedSize;
+        while (originalIndex > 0 || revisedIndex > 0) {
+            if (originalIndex > 0 && revisedIndex > 0
+                && a.get(originalIndex - 1).equals(b.get(revisedIndex - 1))) {
+                result.add(new Edit(0, a.get(originalIndex - 1)));
+                originalIndex--;
+                revisedIndex--;
+            } else if (revisedIndex > 0
+                && (originalIndex == 0
+                    || dp[originalIndex][revisedIndex - 1] >= dp[originalIndex - 1][revisedIndex])) {
+                result.add(new Edit(1, b.get(revisedIndex - 1)));
+                revisedIndex--;
             } else {
-                result.add(new Edit(-1, a.get(i - 1)));
-                i--;
+                result.add(new Edit(-1, a.get(originalIndex - 1)));
+                originalIndex--;
             }
         }
         Collections.reverse(result);

--- a/src/main/java/io/github/yuokada/subcommand/Format.java
+++ b/src/main/java/io/github/yuokada/subcommand/Format.java
@@ -7,12 +7,14 @@ import io.github.yuokada.EntryCommand;
 import io.github.yuokada.core.CommentPreservingFormatter;
 import io.github.yuokada.core.ExitCodes;
 import io.github.yuokada.core.KeywordCaseTransformer;
+import io.github.yuokada.core.UnifiedDiff;
 import io.github.yuokada.core.KeywordCaseTransformer.KeywordCase;
 import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.util.SqlInput;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Statement;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
@@ -61,6 +63,14 @@ public class Format implements Callable<Integer> {
     private boolean check;
 
     /**
+     * When true, print a colored unified diff of what would change without writing output.
+     * Exits with {@link ExitCodes#WARNING} when differences are found.
+     */
+    @CommandLine.Option(names = {"--diff"},
+        description = "Show unified diff of formatting changes; exit 1 if not already formatted.")
+    private boolean diff;
+
+    /**
      * SQL keyword case mode. One of {@code upper} (default), {@code lower}, or {@code keep}.
      */
     @CommandLine.Option(names = {"--keyword-case"}, defaultValue = "upper",
@@ -101,9 +111,13 @@ public class Format implements Callable<Integer> {
             return ExitCodes.ERROR;
         }
 
-        if (this.check && isStdin) {
-            System.err.println("--check is not supported for stdin input");
+        if ((this.check || this.diff) && isStdin) {
+            System.err.println("--check/--diff is not supported for stdin input");
             return ExitCodes.ERROR;
+        }
+
+        if (this.diff) {
+            return runDiffMode(this.sqlFile, kc);
         }
 
         if (this.check) {
@@ -163,6 +177,40 @@ public class Format implements Callable<Integer> {
             return ExitCodes.WARNING;
         }
         return ExitCodes.OK;
+    }
+
+    /**
+     * Computes and prints a unified diff between the current contents of {@code path}
+     * and the formatted output, then returns {@link ExitCodes#WARNING} when differences
+     * are found or {@link ExitCodes#OK} when the file is already formatted.
+     *
+     * <p>Color is enabled automatically when a terminal is attached ({@code System.console() != null}).
+     *
+     * @param path the file path to diff
+     * @param kc   the keyword case mode to apply during formatting
+     * @return {@link ExitCodes#OK} when already formatted, {@link ExitCodes#WARNING} otherwise
+     * @throws IOException if the file cannot be read
+     */
+    private Integer runDiffMode(String path, KeywordCase kc) throws IOException {
+        String original = normalizeNewlines(SqlInput.readFileUtf8(path)).stripTrailing();
+        StringBuilder formatted = new StringBuilder();
+        SqlInput.forEachStatementFromFile(path, stmt -> {
+            formatted.append(formatStatement(stmt, kc)).append(";\n");
+        });
+        String formattedStr = normalizeNewlines(formatted.toString()).stripTrailing();
+        if (formattedStr.equals(original)) {
+            return ExitCodes.OK;
+        }
+        boolean colorize = System.console() != null;
+        String diff = UnifiedDiff.compute(
+            Arrays.asList(original.split("\n", -1)),
+            Arrays.asList(formattedStr.split("\n", -1)),
+            path,
+            path,
+            3,
+            colorize);
+        System.out.print(diff);
+        return ExitCodes.WARNING;
     }
 
     /**
@@ -302,5 +350,9 @@ public class Format implements Callable<Integer> {
 
     void setMaxLineLength(int value) {
         this.maxLineLength = value;
+    }
+
+    void setDiff(boolean value) {
+        this.diff = value;
     }
 }

--- a/src/main/resources/queries/case_expressions.sql
+++ b/src/main/resources/queries/case_expressions.sql
@@ -1,0 +1,26 @@
+SELECT
+    id,
+    CASE status
+        WHEN 'active' THEN 1
+        WHEN 'inactive' THEN 0
+        ELSE -1
+    END AS status_code,
+    CASE
+        WHEN score >= 90 THEN 'A'
+        WHEN score >= 80 THEN 'B'
+        WHEN score >= 70 THEN 'C'
+        ELSE 'F'
+    END AS grade
+FROM students;
+
+SELECT
+    order_id,
+    amount,
+    CASE
+        WHEN amount > 1000 THEN 'large'
+        WHEN amount > 100 THEN 'medium'
+        ELSE 'small'
+    END AS size_category,
+    SUM(CASE WHEN status = 'complete' THEN amount ELSE 0 END) AS completed_total
+FROM orders
+GROUP BY order_id, amount, status;

--- a/src/main/resources/queries/complex_joins.sql
+++ b/src/main/resources/queries/complex_joins.sql
@@ -1,0 +1,22 @@
+SELECT
+    o.order_id,
+    c.name AS customer_name,
+    p.name AS product_name,
+    oi.quantity,
+    oi.unit_price
+FROM catalog1.sales.orders o
+INNER JOIN catalog1.sales.customers c ON o.customer_id = c.id
+LEFT JOIN catalog1.sales.order_items oi ON o.order_id = oi.order_id
+LEFT JOIN catalog1.sales.products p ON oi.product_id = p.id
+WHERE o.order_date >= DATE '2024-01-01'
+    AND c.region = 'APAC'
+ORDER BY o.order_id, oi.line_num;
+
+SELECT
+    a.id,
+    b.val,
+    c.label
+FROM t1 a
+CROSS JOIN t2 b
+FULL OUTER JOIN t3 c ON a.key = c.key
+WHERE b.val IS NOT NULL;

--- a/src/main/resources/queries/subqueries.sql
+++ b/src/main/resources/queries/subqueries.sql
@@ -1,0 +1,38 @@
+SELECT
+    id,
+    name,
+    total_spent
+FROM (
+    SELECT
+        c.id,
+        c.name,
+        SUM(o.amount) AS total_spent
+    FROM catalog1.sales.customers c
+    JOIN catalog1.sales.orders o ON c.id = o.customer_id
+    GROUP BY c.id, c.name
+) sub
+WHERE total_spent > 1000
+ORDER BY total_spent DESC;
+
+SELECT id, score
+FROM results
+WHERE score > (SELECT AVG(score) FROM results WHERE category = 'math')
+    AND id IN (SELECT student_id FROM enrolled WHERE course = 'advanced');
+
+WITH top_products AS (
+    SELECT product_id, SUM(quantity) AS total_qty
+    FROM catalog1.sales.order_items
+    GROUP BY product_id
+    HAVING SUM(quantity) > 100
+),
+ranked AS (
+    SELECT
+        p.name,
+        tp.total_qty,
+        RANK() OVER (ORDER BY tp.total_qty DESC) AS rnk
+    FROM top_products tp
+    JOIN catalog1.sales.products p ON tp.product_id = p.id
+)
+SELECT name, total_qty, rnk
+FROM ranked
+WHERE rnk <= 10;

--- a/src/test/java/io/github/yuokada/subcommand/FormatTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/FormatTest.java
@@ -340,4 +340,55 @@ class FormatTest {
         // Output should remain identical after reformatting (formatting idempotence)
         assertEquals(first, second);
     }
+
+    @Test
+    void testDiffMode_alreadyFormatted(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("formatted.sql");
+        Files.writeString(sqlFile, "SELECT *\nFROM\n  foo\n;");
+
+        Format format = new Format();
+        format.setSqlFile(sqlFile.toString());
+        format.setDiff(true);
+        int exitCode = format.call();
+
+        assertEquals(ExitCodes.OK, exitCode, "Already-formatted SQL should exit OK");
+        assertEquals("", outContent.toString(StandardCharsets.UTF_8),
+            "No diff output expected when file is already formatted");
+    }
+
+    @Test
+    void testDiffMode_needsReformat(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("unformatted.sql");
+        Files.writeString(sqlFile, "select * from foo;");
+
+        Format format = new Format();
+        format.setSqlFile(sqlFile.toString());
+        format.setDiff(true);
+        int exitCode = format.call();
+
+        assertEquals(ExitCodes.WARNING, exitCode, "Unformatted SQL should exit WARNING");
+        String output = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("---"), "Diff should contain --- header");
+        assertTrue(output.contains("+++"), "Diff should contain +++ header");
+        assertTrue(output.contains("@@"), "Diff should contain @@ hunk header");
+    }
+
+    @Test
+    void testDiffMode_stdin_returnsError() throws IOException {
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+        try {
+            Format format = new Format();
+            format.setSqlFile("");
+            format.setDiff(true);
+            int exitCode = format.call();
+
+            assertEquals(ExitCodes.ERROR, exitCode, "--diff with stdin should exit ERROR");
+            assertTrue(errContent.toString().contains("--check/--diff"),
+                "Error message should mention --check/--diff");
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
 }

--- a/src/test/java/io/github/yuokada/subcommand/GoldenFormatTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/GoldenFormatTest.java
@@ -56,7 +56,15 @@ class GoldenFormatTest {
      * @return stream of SQL file names
      */
     static Stream<String> sqlFileNames() {
-        return Stream.of("query1.sql", "query2.sql", "query4.sql", "sample.sql");
+        return Stream.of(
+            "query1.sql",
+            "query2.sql",
+            "query4.sql",
+            "sample.sql",
+            "case_expressions.sql",
+            "complex_joins.sql",
+            "subqueries.sql"
+        );
     }
 
     @ParameterizedTest(name = "{0}")

--- a/src/test/java/io/github/yuokada/subcommand/TrinoDialectFormatTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/TrinoDialectFormatTest.java
@@ -1,0 +1,328 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests verifying that the formatter handles Trino-specific SQL dialect constructs
+ * (TRY, UNNEST, MAP, ARRAY, LAMBDA, TRY_CAST, ROW, JSON functions, etc.) without errors.
+ */
+class TrinoDialectFormatTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final java.io.InputStream originalIn = System.in;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setIn(originalIn);
+    }
+
+    private String formatSql(String sql) throws IOException {
+        outContent.reset();
+        System.setIn(new ByteArrayInputStream(sql.getBytes(StandardCharsets.UTF_8)));
+        Format format = new Format();
+        format.setSqlFile("-");
+        format.call();
+        return outContent.toString(StandardCharsets.UTF_8).trim();
+    }
+
+    // ---- TRY() ---------------------------------------------------------------
+
+    @Test
+    void testTry_parsesWithoutError() throws IOException {
+        String sql = "SELECT TRY(CAST(val AS INTEGER)) FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TRY"), "TRY() should appear in output: " + result);
+    }
+
+    @Test
+    void testTryArithmetic() throws IOException {
+        String sql = "SELECT TRY(1 / 0) AS safe_div FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TRY"), "TRY() should appear in formatted output: " + result);
+    }
+
+    // ---- TRY_CAST() ----------------------------------------------------------
+
+    @Test
+    void testTryCast_parsesWithoutError() throws IOException {
+        String sql = "SELECT TRY_CAST(val AS BIGINT) FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TRY_CAST"), "TRY_CAST should appear in output: " + result);
+        assertTrue(result.contains("BIGINT"), "Target type should appear: " + result);
+    }
+
+    @Test
+    void testTryCast_withFilter() throws IOException {
+        String sql = "SELECT id, TRY_CAST(amount AS DOUBLE) AS amt FROM orders WHERE id > 0;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TRY_CAST"), "TRY_CAST should be preserved: " + result);
+    }
+
+    // ---- UNNEST() ------------------------------------------------------------
+
+    @Test
+    void testUnnest_basic() throws IOException {
+        String sql = "SELECT v FROM t CROSS JOIN UNNEST(arr) AS u(v);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("UNNEST"), "UNNEST should appear in output: " + result);
+    }
+
+    @Test
+    void testUnnest_withOrdinality() throws IOException {
+        String sql = "SELECT v, idx FROM t CROSS JOIN UNNEST(arr) WITH ORDINALITY AS u(v, idx);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("UNNEST"), "UNNEST should appear: " + result);
+        assertTrue(result.contains("ORDINALITY"), "WITH ORDINALITY should appear: " + result);
+    }
+
+    @Test
+    void testUnnest_multipleArrays() throws IOException {
+        String sql = "SELECT a, b FROM UNNEST(ARRAY[1,2,3], ARRAY['x','y','z']) AS t(a, b);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("UNNEST"), "UNNEST should appear: " + result);
+    }
+
+    // ---- ARRAY[] / ARRAY constructor -----------------------------------------
+
+    @Test
+    void testArrayConstructor() throws IOException {
+        String sql = "SELECT ARRAY[1, 2, 3] AS nums;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ARRAY"), "ARRAY should appear: " + result);
+    }
+
+    @Test
+    void testArrayAgg() throws IOException {
+        String sql = "SELECT ARRAY_AGG(id ORDER BY id) AS ids FROM t GROUP BY cat;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ARRAY_AGG"), "ARRAY_AGG should appear: " + result);
+    }
+
+    @Test
+    void testArrayContains() throws IOException {
+        String sql = "SELECT * FROM t WHERE CONTAINS(tags, 'premium');";
+        String result = formatSql(sql);
+        assertDoesNotThrow(() -> formatSql(sql),
+            "CONTAINS() should parse without error");
+    }
+
+    // ---- MAP() ---------------------------------------------------------------
+
+    @Test
+    void testMapConstructor() throws IOException {
+        String sql = "SELECT MAP(ARRAY['a','b'], ARRAY[1,2]) AS m;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("MAP"), "MAP should appear: " + result);
+    }
+
+    @Test
+    void testMapAgg() throws IOException {
+        String sql = "SELECT MAP_AGG(k, v) FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("MAP_AGG"), "MAP_AGG should appear: " + result);
+    }
+
+    @Test
+    void testMapFromEntries() throws IOException {
+        String sql = "SELECT MAP_FROM_ENTRIES(ARRAY[ROW('a',1),ROW('b',2)]) AS m;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("MAP_FROM_ENTRIES"), "MAP_FROM_ENTRIES should appear: " + result);
+    }
+
+    // ---- ROW() ---------------------------------------------------------------
+
+    @Test
+    void testRowConstructor() throws IOException {
+        String sql = "SELECT ROW(1, 'hello', TRUE) AS r;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ROW"), "ROW should appear: " + result);
+    }
+
+    @Test
+    void testRowWithCast() throws IOException {
+        String sql = "SELECT CAST(ROW(1, 2.0) AS ROW(x INTEGER, y DOUBLE)) AS point;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ROW"), "ROW type should appear: " + result);
+    }
+
+    // ---- LAMBDA expressions --------------------------------------------------
+
+    @Test
+    void testLambda_filter() throws IOException {
+        String sql = "SELECT FILTER(arr, x -> x > 0) FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("FILTER"), "FILTER should appear: " + result);
+        assertTrue(result.contains("->"), "Lambda arrow should appear: " + result);
+    }
+
+    @Test
+    void testLambda_transform() throws IOException {
+        String sql = "SELECT TRANSFORM(arr, x -> x * 2) AS doubled FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TRANSFORM"), "TRANSFORM should appear: " + result);
+        assertTrue(result.contains("->"), "Lambda arrow should appear: " + result);
+    }
+
+    @Test
+    void testLambda_reduce() throws IOException {
+        String sql = "SELECT REDUCE(arr, 0, (acc, x) -> acc + x, acc -> acc) AS total FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("REDUCE"), "REDUCE should appear: " + result);
+    }
+
+    @Test
+    void testLambda_zip_with() throws IOException {
+        String sql = "SELECT ZIP_WITH(a1, a2, (x, y) -> x + y) FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ZIP_WITH"), "ZIP_WITH should appear: " + result);
+    }
+
+    // ---- JSON functions ------------------------------------------------------
+
+    @Test
+    void testJsonFormat() throws IOException {
+        String sql = "SELECT JSON_FORMAT(JSON '{\"key\":\"val\"}') AS j;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("JSON_FORMAT"), "JSON_FORMAT should appear: " + result);
+    }
+
+    @Test
+    void testJsonExtractScalar() throws IOException {
+        String sql = "SELECT JSON_EXTRACT_SCALAR(payload, '$.id') AS id FROM events;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("JSON_EXTRACT_SCALAR"),
+            "JSON_EXTRACT_SCALAR should appear: " + result);
+    }
+
+    @Test
+    void testJsonArrayContains() throws IOException {
+        String sql = "SELECT * FROM t WHERE JSON_ARRAY_CONTAINS(tags, 'admin');";
+        String result = formatSql(sql);
+        assertTrue(result.contains("JSON_ARRAY_CONTAINS"),
+            "JSON_ARRAY_CONTAINS should appear: " + result);
+    }
+
+    // ---- Type-cast / TYPE syntax ---------------------------------------------
+
+    @Test
+    void testIntervalLiteral() throws IOException {
+        String sql = "SELECT * FROM t WHERE ts > NOW() - INTERVAL '7' DAY;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("INTERVAL"), "INTERVAL should appear: " + result);
+    }
+
+    @Test
+    void testTimestampLiteral() throws IOException {
+        String sql = "SELECT TIMESTAMP '2024-01-01 00:00:00' AS epoch;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TIMESTAMP"), "TIMESTAMP literal should appear: " + result);
+    }
+
+    @Test
+    void testDecimalLiteral() throws IOException {
+        String sql = "SELECT DECIMAL '3.14' AS pi;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("DECIMAL"), "DECIMAL literal should appear: " + result);
+    }
+
+    // ---- Window functions ----------------------------------------------------
+
+    @Test
+    void testWindowFunctionWithFrame() throws IOException {
+        String sql = "SELECT id, SUM(amt) OVER ("
+            + "PARTITION BY cat ORDER BY ts ROWS BETWEEN 6 PRECEDING AND CURRENT ROW"
+            + ") AS rolling7 FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("PARTITION BY"), "PARTITION BY should appear: " + result);
+        assertTrue(result.contains("ROWS BETWEEN"), "ROWS BETWEEN should appear: " + result);
+    }
+
+    @Test
+    void testNthValue() throws IOException {
+        String sql = "SELECT NTH_VALUE(val, 3) OVER (ORDER BY ts) AS third FROM t;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("NTH_VALUE"), "NTH_VALUE should appear: " + result);
+    }
+
+    // ---- GROUPING SETS / ROLLUP / CUBE ----------------------------------------
+
+    @Test
+    void testGroupingSets() throws IOException {
+        String sql = "SELECT cat, sub, SUM(amt) FROM t GROUP BY GROUPING SETS ((cat, sub), (cat), ());";
+        String result = formatSql(sql);
+        assertTrue(result.contains("GROUPING SETS"), "GROUPING SETS should appear: " + result);
+    }
+
+    @Test
+    void testRollup() throws IOException {
+        String sql = "SELECT cat, sub, SUM(amt) FROM t GROUP BY ROLLUP (cat, sub);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("ROLLUP"), "ROLLUP should appear: " + result);
+    }
+
+    @Test
+    void testCube() throws IOException {
+        String sql = "SELECT cat, sub, SUM(amt) FROM t GROUP BY CUBE (cat, sub);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("CUBE"), "CUBE should appear: " + result);
+    }
+
+    // ---- TABLESAMPLE ---------------------------------------------------------
+
+    @Test
+    void testTableSampleBernoulli() throws IOException {
+        String sql = "SELECT * FROM orders TABLESAMPLE BERNOULLI (10);";
+        String result = formatSql(sql);
+        assertTrue(result.contains("TABLESAMPLE"), "TABLESAMPLE should appear: " + result);
+        assertTrue(result.contains("BERNOULLI"), "BERNOULLI should appear: " + result);
+    }
+
+    // ---- EXCEPT / INTERSECT --------------------------------------------------
+
+    @Test
+    void testExcept() throws IOException {
+        String sql = "SELECT id FROM a EXCEPT SELECT id FROM b;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("EXCEPT"), "EXCEPT should appear: " + result);
+    }
+
+    @Test
+    void testIntersect() throws IOException {
+        String sql = "SELECT id FROM a INTERSECT SELECT id FROM b;";
+        String result = formatSql(sql);
+        assertTrue(result.contains("INTERSECT"), "INTERSECT should appear: " + result);
+    }
+
+    // ---- Keywords remain uppercase by default --------------------------------
+
+    @Test
+    void testKeywordsUppercase_default() throws IOException {
+        // Trino-parser formats type names in lowercase; SQL keywords (SELECT, FROM, AS) are upper.
+        String sql = "select try_cast(v as integer) from t;";
+        String result = formatSql(sql);
+        // TRY_CAST and AS are SQL keywords → uppercased; 'integer' is a type name → formatter
+        // emits lowercase. SELECT and FROM are keywords → uppercased.
+        assertTrue(result.contains("SELECT"), "SELECT should be uppercased: " + result);
+        assertTrue(result.contains("FROM"), "FROM should be uppercased: " + result);
+        assertTrue(result.contains("TRY_CAST"), "TRY_CAST should be uppercased: " + result);
+        assertTrue(result.contains("AS"), "AS should be uppercased: " + result);
+    }
+}

--- a/src/test/resources/queries/expected/case_expressions.expected.sql
+++ b/src/test/resources/queries/expected/case_expressions.expected.sql
@@ -1,0 +1,16 @@
+SELECT
+  id
+, (CASE status WHEN 'active' THEN 1 WHEN 'inactive' THEN 0 ELSE -1 END) status_code
+, (CASE WHEN (score >= 90) THEN 'A' WHEN (score >= 80) THEN 'B' WHEN (score >= 70) THEN 'C' ELSE 'F' END) grade
+FROM
+  students
+;
+SELECT
+  order_id
+, amount
+, (CASE WHEN (amount > 1000) THEN 'large' WHEN (amount > 100) THEN 'medium' ELSE 'small' END) size_category
+, SUM((CASE WHEN (status = 'complete') THEN amount ELSE 0 END)) completed_total
+FROM
+  orders
+GROUP BY order_id, amount, status
+;

--- a/src/test/resources/queries/expected/complex_joins.expected.sql
+++ b/src/test/resources/queries/expected/complex_joins.expected.sql
@@ -1,0 +1,24 @@
+SELECT
+  o.order_id
+, c.name customer_name
+, p.name product_name
+, oi.quantity
+, oi.unit_price
+FROM
+  (((catalog1.sales.orders o
+INNER JOIN catalog1.sales.customers c ON (o.customer_id = c.id))
+LEFT JOIN catalog1.sales.order_items oi ON (o.order_id = oi.order_id))
+LEFT JOIN catalog1.sales.products p ON (oi.product_id = p.id))
+WHERE ((o.order_date >= DATE '2024-01-01') AND (c.region = 'APAC'))
+ORDER BY o.order_id ASC, oi.line_num ASC
+;
+SELECT
+  a.id
+, b.val
+, c.label
+FROM
+  ((t1 a
+CROSS JOIN t2 b)
+FULL JOIN t3 c ON (a.key = c.key))
+WHERE (b.val IS NOT NULL)
+;

--- a/src/test/resources/queries/expected/subqueries.expected.sql
+++ b/src/test/resources/queries/expected/subqueries.expected.sql
@@ -1,0 +1,60 @@
+SELECT
+  id
+, name
+, total_spent
+FROM
+  (
+   SELECT
+     c.id
+   , c.name
+   , SUM(o.amount) total_spent
+   FROM
+     (catalog1.sales.customers c
+   INNER JOIN catalog1.sales.orders o ON (c.id = o.customer_id))
+   GROUP BY c.id, c.name
+)  sub
+WHERE (total_spent > 1000)
+ORDER BY total_spent DESC
+;
+SELECT
+  id
+, score
+FROM
+  results
+WHERE ((score > (SELECT AVG(score)
+FROM
+  results
+WHERE (category = 'math')
+)) AND (id IN (SELECT student_id
+FROM
+  enrolled
+WHERE (course = 'advanced')
+)))
+;
+WITH
+  top_products AS (
+   SELECT
+     product_id
+   , SUM(quantity) total_qty
+   FROM
+     catalog1.sales.order_items
+   GROUP BY product_id
+   HAVING (SUM(quantity) > 100)
+) 
+, ranked AS (
+   SELECT
+     p.name
+   , tp.total_qty
+   , RANK() OVER (ORDER BY tp.total_qty DESC) rnk
+   FROM
+     (top_products tp
+   INNER JOIN catalog1.sales.products p ON (tp.product_id = p.id))
+) 
+SELECT
+  name
+, total_qty
+, rnk
+FROM
+  ranked
+WHERE (rnk <= 10)
+;


### PR DESCRIPTION
## Summary

- **`--diff` option** (`UnifiedDiff.java` + `Format.java`): Prints a colored unified diff of formatting changes. Exits with code 1 (WARNING) when differences are found, code 0 (OK) when already formatted. Color is auto-detected via `System.console()`. Not supported for stdin input.
- **Trino dialect tests** (`TrinoDialectFormatTest.java`): 34 tests verifying the formatter correctly parses and outputs Trino-specific constructs — TRY(), TRY_CAST(), UNNEST (+ WITH ORDINALITY), MAP(), ARRAY[], ROW(), lambda expressions (FILTER/TRANSFORM/REDUCE/ZIP_WITH), JSON functions, window frame clauses, GROUPING SETS/ROLLUP/CUBE, TABLESAMPLE BERNOULLI, EXCEPT, and INTERSECT.
- **Golden tests for CASE/JOIN/subquery** (`GoldenFormatTest` extended): Three new SQL input files + expected snapshots documenting the formatter's behavior for CASE expressions, multi-JOIN patterns (INNER/LEFT/CROSS/FULL OUTER), and correlated/CTE subqueries.

## Test plan
- [x] `./mvnw verify` — 134 tests, 0 failures, checkstyle passes
- [x] `FormatTest`: 3 new `--diff` tests (already formatted → OK, needs reformat → WARNING + diff output, stdin → ERROR)
- [x] `TrinoDialectFormatTest`: 34 dialect tests all pass
- [x] `GoldenFormatTest`: 7 tests pass (3 new golden files for case_expressions, complex_joins, subqueries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)