### PR TITLE
Add UDF validation: W002 (unknown functions) and W003 (arity checking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ format [options] [<file>]
 | `<file>` | stdin | SQL file to format. Use `-` to read from stdin explicitly. |
 | `-o, --output <path>` | stdout | Write formatted output to this file instead of stdout. |
 | `--check` | false | Check if the file is already formatted. Exits `1` when reformatting is needed. Not supported for stdin. |
+| `--diff` | false | Print a unified diff of formatting changes. Exits `1` when differences are found. Not supported for stdin. Color auto-detected via terminal. |
 | `--keyword-case <mode>` | `upper` | Keyword case: `upper` (default), `lower`, or `keep` (preserve original casing). |
 | `--indent-size <n>` | `2` | Spaces per indentation level. Must be ≥ 1. |
 | `--max-line-length <n>` | `0` | Warn to stderr when a formatted line exceeds this length. `0` = unlimited. |
@@ -122,6 +123,14 @@ echo "select * from foo;" | format -
 cat *.sql | format -
 ```
 
+### Diff mode
+
+```bash
+format --diff query.sql
+# Prints a unified diff (like `git diff`) between the current file and its formatted version.
+# Exit 0 if already formatted, exit 1 if reformatting would change the file.
+```
+
 ### Regenerate golden test snapshots
 
 ```bash
@@ -148,9 +157,13 @@ analyze [options] [<file>]
 | `--details <level>` | `basic` | Detail level: `basic` (catalogs only) or `full` (all fields + lint). |
 | `--output <path>` | stdout | Write output to this file instead of stdout. |
 | `--show-ast` | false | Print the AST for the query. |
+| `--ast-view <mode>` | `tree` | AST display mode: `tree` (enriched), `outline` (clause summary), `raw` (class names). |
+| `--ast-depth <n>` | `0` | Maximum AST depth to display. `0` = unlimited. |
 | `--ast-limit <n>` | `10000` | Maximum characters for the embedded AST in JSON output. |
 | `--catalog <name>` | — | Default catalog for partially qualified names (`schema.table`). |
 | `--schema <name>` | — | Default schema for unqualified names (`table`), requires `--catalog`. |
+| `--validate-functions` | false | Flag functions that are not Trino built-ins as **W002** lint warnings. |
+| `--known-functions <list\|@file>` | — | Comma-separated list of additional known function names, or `@path` to a text file (one name per line). Requires `--validate-functions`. |
 
 ### Text output (basic — default)
 
@@ -202,11 +215,40 @@ analyze --catalog my_catalog --details full query.sql
 analyze --catalog my_catalog --schema my_schema --details full query.sql
 ```
 
+### UDF / function validation
+
+When `--validate-functions` is passed, each function call is looked up against the Trino 435
+built-in function catalog. Functions not found there produce a `W002` lint warning.
+Use `--known-functions` to declare project-specific UDFs so they are not flagged.
+
+```bash
+# Flag unknown functions
+analyze --validate-functions --details full query.sql
+
+# Suppress warnings for known UDFs
+analyze --validate-functions --known-functions "my_etl_transform,date_to_epoch" query.sql
+
+# Load UDF list from file (one name per line, # comments ignored)
+analyze --validate-functions --known-functions @udfs.txt query.sql
+```
+
+Example output with an unknown function:
+```
+=========================
+Catalogs: [catalog1]
+QueryType: Query
+Tables: [catalog1.s.t]
+Functions: scalar=[my_etl_transform,upper], aggregate=[count], window=[]
+UnknownFunctions: [my_etl_transform]
+Lint: [WARNING] W002: Unknown function: my_etl_transform; may be a custom UDF or typo
+```
+
 ### Lint rules
 
 | Rule | Severity | Trigger |
 |---|---|---|
 | `W001` | WARNING | `SELECT *` detected; prefer an explicit column list. |
+| `W002` | WARNING | Function name not found in Trino built-in catalog (requires `--validate-functions`). |
 | `E001` | ERROR | `DELETE` without a `WHERE` clause will affect all rows. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -243,12 +243,53 @@ UnknownFunctions: [my_etl_transform]
 Lint: [WARNING] W002: Unknown function: my_etl_transform; may be a custom UDF or typo
 ```
 
+### UDF validation scope
+
+The following table summarises what can and cannot be validated without a live Trino cluster.
+
+| Validation | Supported | Method |
+|---|---|---|
+| Function existence | ✅ (W002) | Look up against built-in catalog |
+| **Argument count (arity)** | 🔜 Planned (W003) | `FunctionCall.getArguments().size()` |
+| Namespace / catalog-specific UDFs | 🔜 Planned | `FunctionCall.getName()` prefix check |
+| Argument types | ❌ Not possible | Requires cluster type inference |
+| Return type | ❌ Not possible | Requires cluster type inference |
+
+#### Future: UDF definition file (planned)
+
+A YAML definition file will allow richer validation such as arity checks:
+
+```yaml
+# udfs.yaml
+functions:
+  - name: my_etl_transform
+    description: "ETL transformation function"
+    arity: 2               # exact argument count
+
+  - name: date_to_epoch
+    arity: 1
+
+  - name: my_variadic_udf
+    minArgs: 1             # variable-length: accepts 1 or more arguments
+```
+
+Planned usage:
+
+```bash
+# Validate against a UDF definition file (arity + existence)
+analyze --validate-functions --udf-catalog udfs.yaml query.sql
+
+# Example output when argument count does not match
+# Lint: [WARNING] W003: Function my_etl_transform expects 2 argument(s), got 1
+```
+
 ### Lint rules
 
 | Rule | Severity | Trigger |
 |---|---|---|
 | `W001` | WARNING | `SELECT *` detected; prefer an explicit column list. |
 | `W002` | WARNING | Function name not found in Trino built-in catalog (requires `--validate-functions`). |
+| `W003` | WARNING | Function call arity does not match the UDF definition (planned). |
 | `E001` | ERROR | `DELETE` without a `WHERE` clause will affect all rows. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ analyze [options] [<file>]
 | `--schema <name>` | — | Default schema for unqualified names (`table`), requires `--catalog`. |
 | `--validate-functions` | false | Flag functions that are not Trino built-ins as **W002** lint warnings. |
 | `--known-functions <list\|@file>` | — | Comma-separated list of additional known function names, or `@path` to a text file (one name per line). Requires `--validate-functions`. |
+| `--udf-catalog <path>` | — | YAML file with UDF definitions for arity validation (**W003**). Functions listed are also treated as known (suppresses W002). |
 
 ### Text output (basic — default)
 
@@ -250,14 +251,14 @@ The following table summarises what can and cannot be validated without a live T
 | Validation | Supported | Method |
 |---|---|---|
 | Function existence | ✅ (W002) | Look up against built-in catalog |
-| **Argument count (arity)** | 🔜 Planned (W003) | `FunctionCall.getArguments().size()` |
+| **Argument count (arity)** | ✅ (W003) | `--udf-catalog` + `FunctionCall.getArguments().size()` |
 | Namespace / catalog-specific UDFs | 🔜 Planned | `FunctionCall.getName()` prefix check |
 | Argument types | ❌ Not possible | Requires cluster type inference |
 | Return type | ❌ Not possible | Requires cluster type inference |
 
-#### Future: UDF definition file (planned)
+#### UDF definition file (`--udf-catalog`)
 
-A YAML definition file will allow richer validation such as arity checks:
+A YAML file declares project-specific UDFs with optional arity constraints:
 
 ```yaml
 # udfs.yaml
@@ -271,12 +272,17 @@ functions:
 
   - name: my_variadic_udf
     minArgs: 1             # variable-length: accepts 1 or more arguments
+
+  - name: bounded_udf
+    minArgs: 2
+    maxArgs: 4             # accepts 2 to 4 arguments
 ```
 
-Planned usage:
-
 ```bash
-# Validate against a UDF definition file (arity + existence)
+# Arity validation only (W003)
+analyze --udf-catalog udfs.yaml query.sql
+
+# Arity validation + unknown-function detection (W002 + W003)
 analyze --validate-functions --udf-catalog udfs.yaml query.sql
 
 # Example output when argument count does not match
@@ -289,7 +295,7 @@ analyze --validate-functions --udf-catalog udfs.yaml query.sql
 |---|---|---|
 | `W001` | WARNING | `SELECT *` detected; prefer an explicit column list. |
 | `W002` | WARNING | Function name not found in Trino built-in catalog (requires `--validate-functions`). |
-| `W003` | WARNING | Function call arity does not match the UDF definition (planned). |
+| `W003` | WARNING | Function call arity does not match the UDF definition (requires `--udf-catalog`). |
 | `E001` | ERROR | `DELETE` without a `WHERE` clause will affect all rows. |
 
 ---

--- a/docs/udf-validation-spec.md
+++ b/docs/udf-validation-spec.md
@@ -252,7 +252,7 @@ JSON:
 | `UdfDefinition` | 1 UDF エントリの POJO (name/description/arity/minArgs/maxArgs) |
 | `UdfCatalog` | YAML ファイルをロードし `Map<String, UdfDefinition>` を返すユーティリティ |
 
-`UdfCatalog.load(Path)` は `YAMLMapper` (Jackson YAML) でデシリアライズし、
+`UdfCatalog.load(Path)` は `ObjectMapper(new YAMLFactory())` (Jackson YAML) でデシリアライズし、
 キーは関数名の小文字。
 
 ---

--- a/docs/udf-validation-spec.md
+++ b/docs/udf-validation-spec.md
@@ -1,0 +1,177 @@
+# UDF Validation 仕様書
+
+## 概要
+
+`analyze` サブコマンドに、SQL 内で使用されている関数を Trino 組み込み関数カタログと照合し、
+未知の関数（カスタム UDF の可能性がある関数）を静的に検出する機能を追加する。
+
+クラスター接続なしで実施できる静的解析の範囲に限定する。
+
+---
+
+## 技術的スコープ
+
+### 実装する検証
+
+| 検証内容 | 手法 |
+|---|---|
+| SQL 構文の正当性 | 既存の `SqlParser` (変更なし) |
+| 関数名の収集 | AST の `FunctionCall` ノード走査 (既存) |
+| 組み込み関数との照合 | `TrinoBuiltinFunctions` カタログとの Set 比較 |
+| 未知関数の報告 | 新しいリスト警告 **W002** として `LintFinding` に追加 |
+| ユーザー定義の既知関数指定 | `--known-functions` オプション (カンマ区切り or `@ファイル`) |
+
+### 実装しない検証
+
+- クラスター接続による実在確認
+- 引数の型チェック
+- 戻り値の型推論
+- UDF のバージョン検証
+
+---
+
+## 新しいクラス・変更一覧
+
+### 1. `TrinoBuiltinFunctions.java` (新規)
+
+`src/main/java/io/github/yuokada/core/TrinoBuiltinFunctions.java`
+
+Trino 435 の組み込み関数名を小文字で管理する定数クラス。
+
+```
+カテゴリ:
+  SCALAR_FUNCTIONS   - 数学・文字列・日時・型変換・配列・Map・JSON・URL・正規表現・バイナリ等
+  AGGREGATE_FUNCTIONS - 集約関数 (count, sum, avg, approx_distinct 等)
+  WINDOW_FUNCTIONS   - ウィンドウ関数 (row_number, rank, lead, lag 等)
+  ALL_BUILTIN_FUNCTIONS = SCALAR_FUNCTIONS ∪ AGGREGATE_FUNCTIONS ∪ WINDOW_FUNCTIONS
+```
+
+主要 API:
+```java
+public static boolean isBuiltin(String functionName)
+public static boolean isAggregate(String functionName)
+public static boolean isWindow(String functionName)
+public static Set<String> allBuiltins()
+```
+
+### 2. `QueryAnalyzer.java` (変更)
+
+- `isAggregateName()` のハードコードリストを `TrinoBuiltinFunctions.isAggregate()` に置き換え
+- `collectExtendedDetails()` に `knownFunctions` パラメータを追加
+- 関数が組み込みカタログにも `knownFunctions` にも含まれない場合、builder に `addUnknownFunction()` で記録
+- `analyze()` メソッドのシグネチャ追加:
+  ```java
+  // 既存 (後方互換維持)
+  public static QueryAnalysisResult analyze(String sql, String defaultCatalog, String defaultSchema)
+  // 新規オーバーロード
+  public static QueryAnalysisResult analyze(String sql, String defaultCatalog,
+      String defaultSchema, Set<String> knownFunctions)
+  ```
+
+### 3. `QueryAnalysisResult.java` (変更)
+
+- `unknownFunctions` フィールドを `Builder` と結果クラスに追加 (`LinkedHashSet<String>`)
+- `getUnknownFunctions()` ゲッター追加
+- `getFindings()` に W002 ルールを追加:
+  ```
+  W002 (WARNING): "Unknown function: {name}; may be a custom UDF or typo"
+  ```
+- `toJson()` に `"unknownFunctions"` フィールドを追加
+
+### 4. `Analyze.java` (変更)
+
+新しい Picocli オプション:
+```
+--validate-functions         未知関数の検出を有効化 (デフォルト: false)
+--known-functions <list>     カンマ区切りの追加既知関数名リスト
+                             例: --known-functions "my_udf,another_udf"
+```
+
+`call()` 内の処理:
+1. `--validate-functions` が true の場合のみ W002 ルールを有効化
+2. `--known-functions` 文字列をパースして `Set<String>` に変換
+3. `QueryAnalyzer.analyze(sql, catalog, schema, knownFunctions)` を呼ぶ
+
+### 5. テスト (新規・変更)
+
+| テストクラス | 内容 |
+|---|---|
+| `TrinoBuiltinFunctionsTest` | カタログの基本的な正当性 (count, array_agg 等が組み込みと判定される) |
+| `UnknownFunctionLintTest` | W002 が正しく生成される / 組み込み関数では生成されない |
+| `AnalyzeValidateFunctionsTest` | `--validate-functions` オプションの end-to-end テスト |
+
+---
+
+## 新しい lint ルール
+
+| ルール ID | 重大度 | メッセージ | トリガー条件 |
+|---|---|---|---|
+| W002 | WARNING | `Unknown function: {name}; may be a custom UDF or typo` | 関数名が組み込みカタログにも `--known-functions` リストにも存在しない場合 |
+
+---
+
+## 出力例
+
+### text 形式 (--details full)
+
+```
+=========================
+Catalogs: [catalog1]
+QueryType: Query
+Tables: [catalog1.s.t]
+Functions: scalar=[my_etl_transform,upper], aggregate=[count], window=[]
+UnknownFunctions: [my_etl_transform]
+Lint: [WARNING] W002: Unknown function: my_etl_transform; may be a custom UDF or typo
+```
+
+### json 形式
+
+```json
+{
+  "queryType": "Query",
+  "catalogs": ["catalog1"],
+  "tables": ["catalog1.s.t"],
+  "functionsScalar": ["my_etl_transform", "upper"],
+  "functionsAggregate": ["count"],
+  "functionsWindow": [],
+  "unknownFunctions": ["my_etl_transform"],
+  "findings": [
+    {"ruleId": "W002", "severity": "WARNING",
+     "message": "Unknown function: my_etl_transform; may be a custom UDF or typo"}
+  ]
+}
+```
+
+---
+
+## --known-functions の利用例
+
+```bash
+# 単発指定
+trino-query-formatter analyze --validate-functions \
+    --known-functions "my_etl_transform,date_to_epoch" query.sql
+
+# UDF リストをファイルで指定 (1行1関数)
+trino-query-formatter analyze --validate-functions \
+    --known-functions @my-udfs.txt query.sql
+```
+
+`@ファイル` 形式は Picocli の `@-file` 機能を使わず、ツール側で解釈する。
+ファイルは UTF-8、1行1関数名、空行・`#` コメント行は無視する。
+
+---
+
+## 後方互換性
+
+- `--validate-functions` を指定しない場合、W002 は生成されない (既存の挙動に変化なし)
+- `QueryAnalyzer.analyze(sql, catalog, schema)` の既存シグネチャは維持
+
+---
+
+## 実装順序
+
+1. `TrinoBuiltinFunctions.java` を作成
+2. `QueryAnalyzer.java` を更新 (新しい analyze オーバーロード)
+3. `QueryAnalysisResult.java` に `unknownFunctions` と W002 を追加
+4. `Analyze.java` に `--validate-functions` / `--known-functions` を追加
+5. テスト作成・全スイート確認

--- a/docs/udf-validation-spec.md
+++ b/docs/udf-validation-spec.md
@@ -102,7 +102,7 @@ public static Set<String> allBuiltins()
 
 ---
 
-## 新しい lint ルール
+## 旧: 新しい lint ルール (W002 のみ)
 
 | ルール ID | 重大度 | メッセージ | トリガー条件 |
 |---|---|---|---|
@@ -161,17 +161,133 @@ trino-query-formatter analyze --validate-functions \
 
 ---
 
+## --udf-catalog オプション (W003 — アリティ検証)
+
+### 概要
+
+`--udf-catalog <yamlファイル>` を指定すると、YAML で定義した UDF の引数数を
+静的に照合し、不一致を **W003** lint 警告として報告する。
+
+### YAML 形式
+
+```yaml
+# udfs.yaml
+functions:
+  - name: my_etl_transform
+    description: "ETL transformation function"
+    arity: 2               # 引数数が 2 でなければ W003
+
+  - name: date_to_epoch
+    arity: 1
+
+  - name: my_variadic_udf
+    minArgs: 1             # 1 以上の引数を受け付ける (上限なし)
+
+  - name: my_bounded_udf
+    minArgs: 2
+    maxArgs: 4             # 2〜4 引数
+
+  - name: my_no_arity_udf  # arity/minArgs を省略するとアリティ検証なし
+    description: "Known UDF with no arity constraint"
+```
+
+- `arity` — 引数数の完全一致。`minArgs`/`maxArgs` より優先される。
+- `minArgs` — 引数数の下限 (省略時 0)。
+- `maxArgs` — 引数数の上限 (省略時: 上限なし)。
+- `description` — 任意の説明文 (検証には使用しない)。
+- YAML ファイルは UTF-8。行コメント (`#`) は YAML 標準として解釈される。
+
+### 利用例
+
+```bash
+# アリティ検証のみ (W002 は出力しない)
+analyze --udf-catalog udfs.yaml query.sql
+
+# W002 (未知関数) + W003 (アリティ不一致) の両方
+analyze --validate-functions --udf-catalog udfs.yaml query.sql
+
+# --known-functions と組み合わせ
+analyze --validate-functions \
+    --known-functions "extra_udf" \
+    --udf-catalog udfs.yaml query.sql
+```
+
+### 動作規則
+
+| オプション組み合わせ | W002 | W003 |
+|---|---|---|
+| なし | なし | なし |
+| `--validate-functions` のみ | あり (組み込み外の関数) | なし |
+| `--udf-catalog` のみ | なし | あり (アリティ不一致) |
+| 両方 | あり (カタログ関数は既知扱い) | あり |
+
+- `--udf-catalog` に含まれる関数は常に「既知」として扱われるため、
+  `--validate-functions` と併用しても W002 は発生しない。
+
+### W003 出力例
+
+```
+=========================
+Catalogs: [catalog1]
+QueryType: Query
+Tables: [catalog1.s.t]
+Functions: scalar=[my_etl_transform,upper], aggregate=[count], window=[]
+Lint: [WARNING] W003: Function my_etl_transform expects 2 argument(s), got 1
+```
+
+JSON:
+```json
+{
+  "findings": [
+    {"ruleId": "W003", "severity": "WARNING",
+     "message": "Function my_etl_transform expects 2 argument(s), got 1"}
+  ]
+}
+```
+
+### 新規クラス
+
+| クラス | 役割 |
+|---|---|
+| `UdfDefinition` | 1 UDF エントリの POJO (name/description/arity/minArgs/maxArgs) |
+| `UdfCatalog` | YAML ファイルをロードし `Map<String, UdfDefinition>` を返すユーティリティ |
+
+`UdfCatalog.load(Path)` は `YAMLMapper` (Jackson YAML) でデシリアライズし、
+キーは関数名の小文字。
+
+---
+
+## 新しい lint ルール (全ルール)
+
+| ルール ID | 重大度 | メッセージ | トリガー条件 |
+|---|---|---|---|
+| W001 | WARNING | `SELECT *` detected; prefer an explicit column list | SELECT * を検出 |
+| W002 | WARNING | `Unknown function: {name}; may be a custom UDF or typo` | `--validate-functions` 時、未知の関数名 |
+| W003 | WARNING | `Function {name} expects {n} argument(s), got {m}` | `--udf-catalog` 時、アリティ不一致 |
+| E001 | ERROR | `DELETE without WHERE clause will affect all rows` | WHERE なしの DELETE |
+
+---
+
 ## 後方互換性
 
 - `--validate-functions` を指定しない場合、W002 は生成されない (既存の挙動に変化なし)
-- `QueryAnalyzer.analyze(sql, catalog, schema)` の既存シグネチャは維持
+- `--udf-catalog` を指定しない場合、W003 は生成されない
+- `QueryAnalyzer.analyze(sql, catalog, schema)` および
+  `QueryAnalyzer.analyze(sql, catalog, schema, knownFunctions)` の
+  既存シグネチャは維持
 
 ---
 
 ## 実装順序
 
-1. `TrinoBuiltinFunctions.java` を作成
-2. `QueryAnalyzer.java` を更新 (新しい analyze オーバーロード)
-3. `QueryAnalysisResult.java` に `unknownFunctions` と W002 を追加
-4. `Analyze.java` に `--validate-functions` / `--known-functions` を追加
-5. テスト作成・全スイート確認
+1. `TrinoBuiltinFunctions.java` を作成 ✅
+2. `QueryAnalyzer.java` を更新 (新しい analyze オーバーロード) ✅
+3. `QueryAnalysisResult.java` に `unknownFunctions` と W002 を追加 ✅
+4. `Analyze.java` に `--validate-functions` / `--known-functions` を追加 ✅
+5. テスト作成・全スイート確認 ✅
+6. `jackson-dataformat-yaml` を `pom.xml` に追加
+7. `UdfDefinition.java` / `UdfCatalog.java` を作成
+8. `QueryAnalysisResult.java` に W003 findings を追加
+9. `QueryAnalyzer.java` に 5 引数 `analyze()` オーバーロードを追加 (アリティ検証)
+10. `Analyze.java` に `--udf-catalog` オプションを追加
+11. テスト作成・全スイート確認

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>

--- a/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
@@ -65,6 +65,11 @@ public final class QueryAnalysisResult {
      * Write target names such as INSERT/CREATE TABLE targets.
      */
     private final Set<String> writeTargets = new LinkedHashSet<>();
+    /**
+     * Function names that are neither Trino built-ins nor user-declared known functions.
+     * Populated only when UDF validation is enabled.
+     */
+    private final Set<String> unknownFunctions = new LinkedHashSet<>();
 
     private QueryAnalysisResult(Builder b) {
         this.queryType = b.queryType;
@@ -80,6 +85,7 @@ public final class QueryAnalysisResult {
         this.functionsAggregate.addAll(b.functionsAggregate);
         this.functionsWindow.addAll(b.functionsWindow);
         this.writeTargets.addAll(b.writeTargets);
+        this.unknownFunctions.addAll(b.unknownFunctions);
     }
 
     /**
@@ -174,11 +180,23 @@ public final class QueryAnalysisResult {
     }
 
     /**
+     * Returns function names that could not be matched to any Trino built-in or
+     * user-declared known function. Non-empty only when UDF validation is enabled
+     * (i.e., {@code --validate-functions} was passed to the analyze subcommand).
+     *
+     * @return unmodifiable set of unknown function names (lowercase)
+     */
+    public Set<String> getUnknownFunctions() {
+        return Collections.unmodifiableSet(unknownFunctions);
+    }
+
+    /**
      * Returns lint findings derived from this analysis result.
      *
      * <p>Current rules:
      * <ul>
      *   <li>{@code W001} — WARNING: {@code SELECT *} detected; prefer explicit column list.</li>
+     *   <li>{@code W002} — WARNING: unknown function detected; may be a custom UDF or typo.</li>
      *   <li>{@code E001} — ERROR: {@code DELETE} without {@code WHERE} will affect all rows.</li>
      * </ul>
      *
@@ -189,6 +207,10 @@ public final class QueryAnalysisResult {
         if (this.usesSelectStar) {
             findings.add(new LintFinding("W001", LintFinding.Severity.WARNING,
                 "SELECT * detected; prefer explicit column list"));
+        }
+        for (String fn : this.unknownFunctions) {
+            findings.add(new LintFinding("W002", LintFinding.Severity.WARNING,
+                "Unknown function: " + fn + "; may be a custom UDF or typo"));
         }
         if (Boolean.FALSE.equals(this.hasWhereOnDelete)) {
             findings.add(new LintFinding("E001", LintFinding.Severity.ERROR,
@@ -215,6 +237,7 @@ public final class QueryAnalysisResult {
         appendArray(sb, "functionsAggregate", functionsAggregate);
         appendArray(sb, "functionsWindow", functionsWindow);
         appendArray(sb, "writeTargets", writeTargets);
+        appendArray(sb, "unknownFunctions", unknownFunctions);
         appendFindingsArray(sb, getFindings());
         if (hasLimit != null) {
             appendField(sb, "hasLimit", Boolean.toString(hasLimit), false);
@@ -329,6 +352,10 @@ public final class QueryAnalysisResult {
          * Write targets.
          */
         private final Set<String> writeTargets = new LinkedHashSet<>();
+        /**
+         * Unknown function names (not in Trino built-ins or user-declared known functions).
+         */
+        private final Set<String> unknownFunctions = new LinkedHashSet<>();
 
         /**
          * @param v query type value
@@ -481,6 +508,17 @@ public final class QueryAnalysisResult {
         public Builder addWriteTarget(String v) {
             if (Objects.nonNull(v)) {
                 writeTargets.add(v);
+            }
+            return this;
+        }
+
+        /**
+         * @param v unknown function name to add (lowercase)
+         * @return Builder instance
+         */
+        public Builder addUnknownFunction(String v) {
+            if (Objects.nonNull(v)) {
+                unknownFunctions.add(v);
             }
             return this;
         }

--- a/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
@@ -70,6 +70,10 @@ public final class QueryAnalysisResult {
      * Populated only when UDF validation is enabled.
      */
     private final Set<String> unknownFunctions = new LinkedHashSet<>();
+    /**
+     * Arity mismatch findings (W003). Populated only when a UDF catalog is provided.
+     */
+    private final List<LintFinding> w003Findings = new ArrayList<>();
 
     private QueryAnalysisResult(Builder b) {
         this.queryType = b.queryType;
@@ -86,6 +90,7 @@ public final class QueryAnalysisResult {
         this.functionsWindow.addAll(b.functionsWindow);
         this.writeTargets.addAll(b.writeTargets);
         this.unknownFunctions.addAll(b.unknownFunctions);
+        this.w003Findings.addAll(b.w003Findings);
     }
 
     /**
@@ -197,6 +202,7 @@ public final class QueryAnalysisResult {
      * <ul>
      *   <li>{@code W001} — WARNING: {@code SELECT *} detected; prefer explicit column list.</li>
      *   <li>{@code W002} — WARNING: unknown function detected; may be a custom UDF or typo.</li>
+     *   <li>{@code W003} — WARNING: function arity does not match UDF catalog definition.</li>
      *   <li>{@code E001} — ERROR: {@code DELETE} without {@code WHERE} will affect all rows.</li>
      * </ul>
      *
@@ -212,6 +218,7 @@ public final class QueryAnalysisResult {
             findings.add(new LintFinding("W002", LintFinding.Severity.WARNING,
                 "Unknown function: " + fn + "; may be a custom UDF or typo"));
         }
+        findings.addAll(this.w003Findings);
         if (Boolean.FALSE.equals(this.hasWhereOnDelete)) {
             findings.add(new LintFinding("E001", LintFinding.Severity.ERROR,
                 "DELETE without WHERE clause will affect all rows"));
@@ -356,6 +363,10 @@ public final class QueryAnalysisResult {
          * Unknown function names (not in Trino built-ins or user-declared known functions).
          */
         private final Set<String> unknownFunctions = new LinkedHashSet<>();
+        /**
+         * W003 arity mismatch findings generated when a UDF catalog is provided.
+         */
+        private final List<LintFinding> w003Findings = new ArrayList<>();
 
         /**
          * @param v query type value
@@ -520,6 +531,21 @@ public final class QueryAnalysisResult {
             if (Objects.nonNull(v)) {
                 unknownFunctions.add(v);
             }
+            return this;
+        }
+
+        /**
+         * Adds a W003 arity-mismatch lint finding.
+         *
+         * @param functionName lowercase function name
+         * @param expectedDesc human-readable description of expected arity (e.g. "2", "at least 1")
+         * @param actualArgs   actual number of arguments in the call
+         * @return Builder instance
+         */
+        public Builder addArityMismatch(String functionName, String expectedDesc, int actualArgs) {
+            String msg = "Function " + functionName + " expects " + expectedDesc
+                + " argument(s), got " + actualArgs;
+            w003Findings.add(new LintFinding("W003", LintFinding.Severity.WARNING, msg));
             return this;
         }
 

--- a/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
@@ -106,6 +106,28 @@ public final class QueryAnalyzer {
      */
     public static QueryAnalysisResult analyze(String sql, String defaultCatalog,
         String defaultSchema) {
+        // Pass null knownFunctions to signal "no UDF validation" — unknown functions are
+        // not collected and no W002 findings are generated.
+        return analyze(sql, defaultCatalog, defaultSchema, null);
+    }
+
+    /**
+     * Performs analysis with optional default catalog/schema and a set of user-defined
+     * known function names.
+     *
+     * <p>Functions found in the SQL that are neither Trino built-ins nor in
+     * {@code knownFunctions} are recorded as unknown functions in the result,
+     * producing a {@code W002} lint finding for each.
+     *
+     * @param sql            SQL statement text
+     * @param defaultCatalog default catalog for un/partially qualified names (nullable)
+     * @param defaultSchema  default schema for unqualified names (nullable)
+     * @param knownFunctions additional user-defined function names to treat as known (nullable)
+     * @return analysis result for the statement
+     */
+    public static QueryAnalysisResult analyze(String sql, String defaultCatalog,
+        String defaultSchema, Set<String> knownFunctions) {
+        Set<String> normalizedKnown = normalizeKnownFunctions(knownFunctions);
         QueryAnalysisResult.Builder b = new QueryAnalysisResult.Builder();
         try {
             Statement statement = sqlParser.createStatement(sql);
@@ -122,13 +144,38 @@ public final class QueryAnalyzer {
             if (statement instanceof Delete del) {
                 b.hasWhereOnDelete(del.getWhere().isPresent());
             }
-            // Extended details
-            collectExtendedDetails(statement, b, defaultCatalog, defaultSchema, catalogs);
+            // Extended details (including unknown function detection)
+            collectExtendedDetails(statement, b, defaultCatalog, defaultSchema, catalogs,
+                normalizedKnown);
             return b.build();
         } catch (RuntimeException e) {
             // Return partial info with parse error message
             return b.queryType("Unknown").parseError(e.getMessage()).build();
         }
+    }
+
+    /**
+     * Normalises a set of user-supplied known function names to lowercase.
+     * Returns {@code null} when {@code knownFunctions} is {@code null},
+     * which signals that UDF validation is disabled.
+     *
+     * @param knownFunctions set of function names (may be null to disable validation)
+     * @return lowercase set, or {@code null} when validation is disabled
+     */
+    private static Set<String> normalizeKnownFunctions(Set<String> knownFunctions) {
+        if (knownFunctions == null) {
+            return null; // null = no validation
+        }
+        if (knownFunctions.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> result = new HashSet<>();
+        for (String fn : knownFunctions) {
+            if (fn != null) {
+                result.add(fn.toLowerCase());
+            }
+        }
+        return result;
     }
 
     /**
@@ -170,15 +217,19 @@ public final class QueryAnalyzer {
 
     /**
      * Collects extended information: CTE names, join descriptors, function usage and write targets.
+     * Functions that are neither Trino built-ins nor in {@code knownFunctions} are recorded
+     * as unknown functions in the builder.
      *
      * @param node           root AST node
      * @param b              result builder to receive findings
      * @param defaultCatalog default catalog (nullable)
      * @param defaultSchema  default schema (nullable)
      * @param catalogs       collected catalog names (for updates during resolution)
+     * @param knownFunctions user-supplied known function names (lowercase, non-null)
      */
     private static void collectExtendedDetails(Node node, QueryAnalysisResult.Builder b,
-        String defaultCatalog, String defaultSchema, java.util.Set<String> catalogs) {
+        String defaultCatalog, String defaultSchema, Set<String> catalogs,
+        Set<String> knownFunctions) {
         if (node instanceof With with) {
             for (WithQuery wq : with.getQueries()) {
                 b.addCte(wq.getName().getValue());
@@ -192,10 +243,16 @@ public final class QueryAnalyzer {
             String lower = fn.toLowerCase();
             if (fc.getWindow().isPresent()) {
                 b.addFunctionWindow(lower);
-            } else if (isAggregateName(lower)) {
+            } else if (TrinoBuiltinFunctions.isAggregate(lower)) {
                 b.addFunctionAggregate(lower);
             } else {
                 b.addFunctionScalar(lower);
+            }
+            // knownFunctions == null means validation is disabled; skip unknown-function check.
+            if (knownFunctions != null
+                && !TrinoBuiltinFunctions.isBuiltin(lower)
+                && !knownFunctions.contains(lower)) {
+                b.addUnknownFunction(lower);
             }
         } else if (node instanceof Insert ins) {
             QualifiedName qn = ins.getTarget();
@@ -213,20 +270,9 @@ public final class QueryAnalyzer {
             b.addWriteTarget(joined);
         }
         for (Node child : node.getChildren()) {
-            collectExtendedDetails(child, b, defaultCatalog, defaultSchema, catalogs);
+            collectExtendedDetails(child, b, defaultCatalog, defaultSchema, catalogs,
+                knownFunctions);
         }
-    }
-
-    /**
-     * Checks if a function name is a common aggregate function.
-     *
-     * @param lower function name in lower case
-     * @return true when name is a known aggregate
-     */
-    private static boolean isAggregateName(String lower) {
-        return lower.equals("count") || lower.equals("sum") || lower.equals("avg")
-            || lower.equals("min") || lower.equals("max") || lower.equals("array_agg")
-            || lower.equals("approx_distinct");
     }
 
     /**
@@ -379,7 +425,7 @@ public final class QueryAnalyzer {
             String category;
             if (fc.getWindow().isPresent()) {
                 category = "window";
-            } else if (isAggregateName(fn)) {
+            } else if (TrinoBuiltinFunctions.isAggregate(fn)) {
                 category = "aggregate";
             } else {
                 category = "scalar";

--- a/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
@@ -28,6 +28,7 @@ import io.trino.sql.tree.With;
 import io.trino.sql.tree.WithQuery;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -127,6 +128,32 @@ public final class QueryAnalyzer {
      */
     public static QueryAnalysisResult analyze(String sql, String defaultCatalog,
         String defaultSchema, Set<String> knownFunctions) {
+        return analyze(sql, defaultCatalog, defaultSchema, knownFunctions, null);
+    }
+
+    /**
+     * Performs analysis with optional default catalog/schema, known function names, and a
+     * UDF catalog for arity validation (W003).
+     *
+     * <p>When {@code udfCatalog} is non-null, each function call whose name appears in the
+     * catalog is validated against the declared arity constraints. Mismatches produce W003
+     * lint findings.
+     *
+     * <p>Functions found in the SQL that are neither Trino built-ins nor in
+     * {@code knownFunctions} are recorded as unknown functions in the result,
+     * producing a {@code W002} lint finding for each (when {@code knownFunctions != null}).
+     *
+     * @param sql            SQL statement text
+     * @param defaultCatalog default catalog for un/partially qualified names (nullable)
+     * @param defaultSchema  default schema for unqualified names (nullable)
+     * @param knownFunctions additional user-defined function names to treat as known (nullable;
+     *                       {@code null} disables W002)
+     * @param udfCatalog     UDF definitions for arity checking (nullable; {@code null} disables
+     *                       W003)
+     * @return analysis result for the statement
+     */
+    public static QueryAnalysisResult analyze(String sql, String defaultCatalog,
+        String defaultSchema, Set<String> knownFunctions, Map<String, UdfDefinition> udfCatalog) {
         Set<String> normalizedKnown = normalizeKnownFunctions(knownFunctions);
         QueryAnalysisResult.Builder b = new QueryAnalysisResult.Builder();
         try {
@@ -144,9 +171,9 @@ public final class QueryAnalyzer {
             if (statement instanceof Delete del) {
                 b.hasWhereOnDelete(del.getWhere().isPresent());
             }
-            // Extended details (including unknown function detection)
+            // Extended details (including unknown function detection and arity checking)
             collectExtendedDetails(statement, b, defaultCatalog, defaultSchema, catalogs,
-                normalizedKnown);
+                normalizedKnown, udfCatalog);
             return b.build();
         } catch (RuntimeException e) {
             // Return partial info with parse error message
@@ -218,18 +245,20 @@ public final class QueryAnalyzer {
     /**
      * Collects extended information: CTE names, join descriptors, function usage and write targets.
      * Functions that are neither Trino built-ins nor in {@code knownFunctions} are recorded
-     * as unknown functions in the builder.
+     * as unknown functions in the builder. When {@code udfCatalog} is non-null, arity is checked
+     * against catalog definitions and W003 findings are added on mismatch.
      *
      * @param node           root AST node
      * @param b              result builder to receive findings
      * @param defaultCatalog default catalog (nullable)
      * @param defaultSchema  default schema (nullable)
      * @param catalogs       collected catalog names (for updates during resolution)
-     * @param knownFunctions user-supplied known function names (lowercase, non-null)
+     * @param knownFunctions user-supplied known function names (lowercase; null = W002 disabled)
+     * @param udfCatalog     UDF definitions for arity checking (nullable; null = W003 disabled)
      */
     private static void collectExtendedDetails(Node node, QueryAnalysisResult.Builder b,
         String defaultCatalog, String defaultSchema, Set<String> catalogs,
-        Set<String> knownFunctions) {
+        Set<String> knownFunctions, Map<String, UdfDefinition> udfCatalog) {
         if (node instanceof With with) {
             for (WithQuery wq : with.getQueries()) {
                 b.addCte(wq.getName().getValue());
@@ -248,11 +277,21 @@ public final class QueryAnalyzer {
             } else {
                 b.addFunctionScalar(lower);
             }
-            // knownFunctions == null means validation is disabled; skip unknown-function check.
+            // knownFunctions == null means W002 is disabled; skip unknown-function check.
             if (knownFunctions != null
                 && !TrinoBuiltinFunctions.isBuiltin(lower)
                 && !knownFunctions.contains(lower)) {
                 b.addUnknownFunction(lower);
+            }
+            // udfCatalog == null means W003 is disabled; skip arity check.
+            if (udfCatalog != null && udfCatalog.containsKey(lower)) {
+                UdfDefinition def = udfCatalog.get(lower);
+                if (def.hasArityConstraint()) {
+                    int actualArgs = fc.getArguments().size();
+                    if (!def.isArityValid(actualArgs)) {
+                        b.addArityMismatch(lower, def.expectedArityDescription(), actualArgs);
+                    }
+                }
             }
         } else if (node instanceof Insert ins) {
             QualifiedName qn = ins.getTarget();
@@ -271,7 +310,7 @@ public final class QueryAnalyzer {
         }
         for (Node child : node.getChildren()) {
             collectExtendedDetails(child, b, defaultCatalog, defaultSchema, catalogs,
-                knownFunctions);
+                knownFunctions, udfCatalog);
         }
     }
 

--- a/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalyzer.java
@@ -268,8 +268,11 @@ public final class QueryAnalyzer {
             String desc = type + ":" + (join.getCriteria().isPresent() ? "on" : "none");
             b.addJoin(desc);
         } else if (node instanceof FunctionCall fc) {
-            String fn = fc.getName().toString();
-            String lower = fn.toLowerCase();
+            // Use the unqualified (last-part) name so that catalog.schema.fn() is treated
+            // the same as fn() for built-in/known-function lookup and arity checking.
+            // QualifiedName.getParts() returns lowercase strings.
+            List<String> nameParts = fc.getName().getParts();
+            String lower = nameParts.get(nameParts.size() - 1);
             if (fc.getWindow().isPresent()) {
                 b.addFunctionWindow(lower);
             } else if (TrinoBuiltinFunctions.isAggregate(lower)) {
@@ -284,9 +287,9 @@ public final class QueryAnalyzer {
                 b.addUnknownFunction(lower);
             }
             // udfCatalog == null means W003 is disabled; skip arity check.
-            if (udfCatalog != null && udfCatalog.containsKey(lower)) {
+            if (udfCatalog != null) {
                 UdfDefinition def = udfCatalog.get(lower);
-                if (def.hasArityConstraint()) {
+                if (def != null && def.hasArityConstraint()) {
                     int actualArgs = fc.getArguments().size();
                     if (!def.isArityValid(actualArgs)) {
                         b.addArityMismatch(lower, def.expectedArityDescription(), actualArgs);

--- a/src/main/java/io/github/yuokada/core/TrinoBuiltinFunctions.java
+++ b/src/main/java/io/github/yuokada/core/TrinoBuiltinFunctions.java
@@ -1,0 +1,449 @@
+package io.github.yuokada.core;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Catalog of Trino 435 built-in function names (all lowercase).
+ *
+ * <p>Function names are stored in three categories:
+ * <ul>
+ *   <li>Scalar functions — math, string, date/time, type conversion, array, map, JSON, etc.</li>
+ *   <li>Aggregate functions — COUNT, SUM, AVG and statistical aggregates.</li>
+ *   <li>Window functions — ROW_NUMBER, RANK, LEAD, LAG, etc.</li>
+ * </ul>
+ *
+ * <p>This catalog is used by the UDF validation feature to identify function calls
+ * that are not part of the Trino built-in function set.
+ */
+public final class TrinoBuiltinFunctions {
+
+    /**
+     * Trino built-in aggregate function names (lowercase).
+     */
+    private static final Set<String> AGGREGATE_FUNCTIONS;
+
+    /**
+     * Trino built-in window function names (lowercase).
+     */
+    private static final Set<String> WINDOW_FUNCTIONS;
+
+    /**
+     * Trino built-in scalar function names (lowercase).
+     */
+    private static final Set<String> SCALAR_FUNCTIONS;
+
+    /**
+     * Union of all three categories.
+     */
+    private static final Set<String> ALL_BUILTIN_FUNCTIONS;
+
+    static {
+        Set<String> agg = new HashSet<>();
+        // General aggregates
+        agg.add("count");
+        agg.add("count_if");
+        agg.add("sum");
+        agg.add("avg");
+        agg.add("min");
+        agg.add("max");
+        agg.add("arbitrary");
+        agg.add("every");
+        agg.add("bool_and");
+        agg.add("bool_or");
+        agg.add("bitwise_and_agg");
+        agg.add("bitwise_or_agg");
+        agg.add("bitwise_xor_agg");
+        agg.add("checksum");
+        agg.add("geometric_mean");
+        agg.add("max_by");
+        agg.add("min_by");
+        // Statistical
+        agg.add("corr");
+        agg.add("covar_pop");
+        agg.add("covar_samp");
+        agg.add("kurtosis");
+        agg.add("skewness");
+        agg.add("stddev");
+        agg.add("stddev_pop");
+        agg.add("stddev_samp");
+        agg.add("variance");
+        agg.add("var_pop");
+        agg.add("var_samp");
+        agg.add("regr_slope");
+        agg.add("regr_intercept");
+        // Array/map aggregates
+        agg.add("array_agg");
+        agg.add("multimap_agg");
+        agg.add("map_agg");
+        agg.add("map_union");
+        agg.add("map_union_sum");
+        agg.add("histogram");
+        agg.add("set_agg");
+        agg.add("set_union");
+        agg.add("reduce_agg");
+        agg.add("list_agg");
+        // Approximate
+        agg.add("approx_distinct");
+        agg.add("approx_most_frequent");
+        agg.add("approx_percentile");
+        agg.add("approx_set");
+        agg.add("merge");
+        agg.add("numeric_histogram");
+        agg.add("qdigest_agg");
+        agg.add("tdigest_agg");
+        // Classification
+        agg.add("classification_fall_out");
+        agg.add("classification_miss_rate");
+        agg.add("classification_precision");
+        agg.add("classification_recall");
+        agg.add("classification_thresholds");
+        AGGREGATE_FUNCTIONS = Collections.unmodifiableSet(agg);
+
+        Set<String> win = new HashSet<>();
+        win.add("row_number");
+        win.add("rank");
+        win.add("dense_rank");
+        win.add("percent_rank");
+        win.add("cume_dist");
+        win.add("ntile");
+        win.add("lag");
+        win.add("lead");
+        win.add("first_value");
+        win.add("last_value");
+        win.add("nth_value");
+        WINDOW_FUNCTIONS = Collections.unmodifiableSet(win);
+
+        Set<String> scalar = new HashSet<>();
+        // ---- Math ----
+        scalar.add("abs");
+        scalar.add("cbrt");
+        scalar.add("ceil");
+        scalar.add("ceiling");
+        scalar.add("degrees");
+        scalar.add("e");
+        scalar.add("exp");
+        scalar.add("floor");
+        scalar.add("from_base");
+        scalar.add("infinity");
+        scalar.add("is_finite");
+        scalar.add("is_infinite");
+        scalar.add("is_nan");
+        scalar.add("ln");
+        scalar.add("log");
+        scalar.add("log2");
+        scalar.add("log10");
+        scalar.add("mod");
+        scalar.add("nan");
+        scalar.add("pi");
+        scalar.add("pow");
+        scalar.add("power");
+        scalar.add("radians");
+        scalar.add("rand");
+        scalar.add("random");
+        scalar.add("round");
+        scalar.add("sign");
+        scalar.add("sqrt");
+        scalar.add("to_base");
+        scalar.add("truncate");
+        scalar.add("width_bucket");
+        // Trigonometry
+        scalar.add("acos");
+        scalar.add("asin");
+        scalar.add("atan");
+        scalar.add("atan2");
+        scalar.add("cos");
+        scalar.add("cosh");
+        scalar.add("sin");
+        scalar.add("sinh");
+        scalar.add("tan");
+        scalar.add("tanh");
+        scalar.add("inverse_normal_cdf");
+        scalar.add("normal_cdf");
+        scalar.add("inverse_beta_cdf");
+        scalar.add("beta_cdf");
+        scalar.add("wilson_interval_lower");
+        scalar.add("wilson_interval_upper");
+        // ---- String ----
+        scalar.add("chr");
+        scalar.add("codepoint");
+        scalar.add("concat");
+        scalar.add("concat_ws");
+        scalar.add("format");
+        scalar.add("from_utf8");
+        scalar.add("hamming_distance");
+        scalar.add("index_of");
+        scalar.add("length");
+        scalar.add("levenshtein_distance");
+        scalar.add("lower");
+        scalar.add("lpad");
+        scalar.add("ltrim");
+        scalar.add("normalize");
+        scalar.add("position");
+        scalar.add("repeat");
+        scalar.add("replace");
+        scalar.add("reverse");
+        scalar.add("rpad");
+        scalar.add("rtrim");
+        scalar.add("soundex");
+        scalar.add("split");
+        scalar.add("split_part");
+        scalar.add("split_to_map");
+        scalar.add("split_to_multimap");
+        scalar.add("starts_with");
+        scalar.add("strpos");
+        scalar.add("substr");
+        scalar.add("substring");
+        scalar.add("to_utf8");
+        scalar.add("translate");
+        scalar.add("trim");
+        scalar.add("upper");
+        scalar.add("word_stem");
+        // ---- Date / Time ----
+        scalar.add("at_timezone");
+        scalar.add("current_date");
+        scalar.add("current_time");
+        scalar.add("current_timestamp");
+        scalar.add("current_timezone");
+        scalar.add("date");
+        scalar.add("date_add");
+        scalar.add("date_diff");
+        scalar.add("date_format");
+        scalar.add("date_parse");
+        scalar.add("date_trunc");
+        scalar.add("day");
+        scalar.add("day_of_month");
+        scalar.add("day_of_week");
+        scalar.add("day_of_year");
+        scalar.add("format_datetime");
+        scalar.add("from_iso8601_date");
+        scalar.add("from_iso8601_timestamp");
+        scalar.add("from_iso8601_timestamp_nanos");
+        scalar.add("from_unixtime");
+        scalar.add("from_unixtime_nanos");
+        scalar.add("hour");
+        scalar.add("last_day_of_month");
+        scalar.add("localtime");
+        scalar.add("localtimestamp");
+        scalar.add("millisecond");
+        scalar.add("minute");
+        scalar.add("month");
+        scalar.add("now");
+        scalar.add("parse_datetime");
+        scalar.add("parse_duration");
+        scalar.add("quarter");
+        scalar.add("second");
+        scalar.add("timezone_hour");
+        scalar.add("timezone_minute");
+        scalar.add("to_iso8601");
+        scalar.add("to_milliseconds");
+        scalar.add("to_unixtime");
+        scalar.add("week");
+        scalar.add("week_of_year");
+        scalar.add("year");
+        scalar.add("year_of_week");
+        scalar.add("yow");
+        // ---- Array ----
+        scalar.add("array_distinct");
+        scalar.add("array_except");
+        scalar.add("array_flatten");
+        scalar.add("array_intersect");
+        scalar.add("array_join");
+        scalar.add("array_max");
+        scalar.add("array_min");
+        scalar.add("array_position");
+        scalar.add("array_remove");
+        scalar.add("array_reverse");
+        scalar.add("array_sort");
+        scalar.add("array_union");
+        scalar.add("arrays_overlap");
+        scalar.add("cardinality");
+        scalar.add("combinations");
+        scalar.add("contains");
+        scalar.add("element_at");
+        scalar.add("filter");
+        scalar.add("flatten");
+        scalar.add("ngrams");
+        scalar.add("reduce");
+        scalar.add("sequence");
+        scalar.add("shuffle");
+        scalar.add("slice");
+        scalar.add("transform");
+        scalar.add("zip");
+        scalar.add("zip_with");
+        // ---- Map ----
+        scalar.add("map");
+        scalar.add("map_concat");
+        scalar.add("map_entries");
+        scalar.add("map_filter");
+        scalar.add("map_from_entries");
+        scalar.add("map_keys");
+        scalar.add("map_values");
+        scalar.add("map_zip_with");
+        scalar.add("transform_keys");
+        scalar.add("transform_values");
+        // ---- JSON ----
+        scalar.add("is_json_scalar");
+        scalar.add("json_array_contains");
+        scalar.add("json_array_get");
+        scalar.add("json_array_length");
+        scalar.add("json_extract");
+        scalar.add("json_extract_scalar");
+        scalar.add("json_format");
+        scalar.add("json_object");
+        scalar.add("json_parse");
+        scalar.add("json_size");
+        // ---- URL ----
+        scalar.add("url_decode");
+        scalar.add("url_encode");
+        scalar.add("url_extract_fragment");
+        scalar.add("url_extract_host");
+        scalar.add("url_extract_parameter");
+        scalar.add("url_extract_path");
+        scalar.add("url_extract_port");
+        scalar.add("url_extract_protocol");
+        scalar.add("url_extract_query");
+        // ---- Regex ----
+        scalar.add("regexp_count");
+        scalar.add("regexp_extract");
+        scalar.add("regexp_extract_all");
+        scalar.add("regexp_like");
+        scalar.add("regexp_position");
+        scalar.add("regexp_replace");
+        scalar.add("regexp_split");
+        // ---- Binary / Hash ----
+        scalar.add("crc32");
+        scalar.add("from_base32");
+        scalar.add("from_base64");
+        scalar.add("from_base64url");
+        scalar.add("from_hex");
+        scalar.add("from_ieee754_32");
+        scalar.add("from_ieee754_64");
+        scalar.add("hmac_md5");
+        scalar.add("hmac_sha1");
+        scalar.add("hmac_sha256");
+        scalar.add("hmac_sha512");
+        scalar.add("md5");
+        scalar.add("sha1");
+        scalar.add("sha256");
+        scalar.add("sha512");
+        scalar.add("spooky_hash_v2_32");
+        scalar.add("spooky_hash_v2_64");
+        scalar.add("to_base32");
+        scalar.add("to_base64");
+        scalar.add("to_base64url");
+        scalar.add("to_hex");
+        scalar.add("to_ieee754_32");
+        scalar.add("to_ieee754_64");
+        scalar.add("xxhash64");
+        // ---- UUID ----
+        scalar.add("uuid");
+        // ---- IP ----
+        scalar.add("ip_prefix");
+        scalar.add("ip_subnet_max");
+        scalar.add("ip_subnet_min");
+        scalar.add("ip_subnet_range");
+        scalar.add("is_subnet_of");
+        scalar.add("canonicalize_ipv6_address_to_ipv4");
+        // ---- Color ----
+        scalar.add("bar");
+        scalar.add("color");
+        scalar.add("render");
+        scalar.add("rgb");
+        // ---- HyperLogLog ----
+        scalar.add("approx_set");
+        scalar.add("cardinality");
+        scalar.add("empty_approx_set");
+        // ---- Type / Conversion ----
+        scalar.add("cast");
+        scalar.add("try_cast");
+        scalar.add("typeof");
+        scalar.add("to_char");
+        // ---- Conditional ----
+        scalar.add("coalesce");
+        scalar.add("greatest");
+        scalar.add("if");
+        scalar.add("least");
+        scalar.add("nullif");
+        scalar.add("try");
+        // ---- Misc ----
+        scalar.add("classify");
+        scalar.add("features");
+        scalar.add("hash_counts");
+        scalar.add("make_set_digest");
+        scalar.add("merge_set_digest");
+        scalar.add("set_digest_element_count");
+        scalar.add("set_digest_intersection_cardinality");
+        scalar.add("jaccard_index");
+        scalar.add("fail");
+        scalar.add("version");
+        scalar.add("last_day_of_month");
+        scalar.add("human_readable_seconds");
+        scalar.add("tdigest_agg");
+        scalar.add("values_at_quantiles");
+        scalar.add("qdigest_agg");
+        scalar.add("value_at_quantile");
+        SCALAR_FUNCTIONS = Collections.unmodifiableSet(scalar);
+
+        Set<String> all = new HashSet<>();
+        all.addAll(AGGREGATE_FUNCTIONS);
+        all.addAll(WINDOW_FUNCTIONS);
+        all.addAll(SCALAR_FUNCTIONS);
+        ALL_BUILTIN_FUNCTIONS = Collections.unmodifiableSet(all);
+    }
+
+    private TrinoBuiltinFunctions() {
+    }
+
+    /**
+     * Returns {@code true} if {@code functionName} (case-insensitive) is a known
+     * Trino built-in function.
+     *
+     * @param functionName the function name to look up
+     * @return {@code true} when the function is a Trino built-in
+     */
+    public static boolean isBuiltin(String functionName) {
+        if (functionName == null) {
+            return false;
+        }
+        return ALL_BUILTIN_FUNCTIONS.contains(functionName.toLowerCase());
+    }
+
+    /**
+     * Returns {@code true} if {@code functionName} (case-insensitive) is a known
+     * Trino built-in aggregate function.
+     *
+     * @param functionName the function name to look up
+     * @return {@code true} when the function is a built-in aggregate
+     */
+    public static boolean isAggregate(String functionName) {
+        if (functionName == null) {
+            return false;
+        }
+        return AGGREGATE_FUNCTIONS.contains(functionName.toLowerCase());
+    }
+
+    /**
+     * Returns {@code true} if {@code functionName} (case-insensitive) is a known
+     * Trino built-in window function.
+     *
+     * @param functionName the function name to look up
+     * @return {@code true} when the function is a built-in window function
+     */
+    public static boolean isWindow(String functionName) {
+        if (functionName == null) {
+            return false;
+        }
+        return WINDOW_FUNCTIONS.contains(functionName.toLowerCase());
+    }
+
+    /**
+     * Returns an unmodifiable view of all known Trino built-in function names (lowercase).
+     *
+     * @return set of all built-in function names
+     */
+    public static Set<String> allBuiltins() {
+        return ALL_BUILTIN_FUNCTIONS;
+    }
+}

--- a/src/main/java/io/github/yuokada/core/TrinoBuiltinFunctions.java
+++ b/src/main/java/io/github/yuokada/core/TrinoBuiltinFunctions.java
@@ -352,8 +352,8 @@ public final class TrinoBuiltinFunctions {
         scalar.add("render");
         scalar.add("rgb");
         // ---- HyperLogLog ----
-        scalar.add("approx_set");
-        scalar.add("cardinality");
+        // approx_set is an aggregate function (already in AGGREGATE_FUNCTIONS)
+        // cardinality is a scalar for arrays/maps (already added above)
         scalar.add("empty_approx_set");
         // ---- Type / Conversion ----
         scalar.add("cast");
@@ -378,11 +378,10 @@ public final class TrinoBuiltinFunctions {
         scalar.add("jaccard_index");
         scalar.add("fail");
         scalar.add("version");
-        scalar.add("last_day_of_month");
+        // last_day_of_month already added in Date/Time section above
         scalar.add("human_readable_seconds");
-        scalar.add("tdigest_agg");
+        // tdigest_agg and qdigest_agg are aggregate functions (already in AGGREGATE_FUNCTIONS)
         scalar.add("values_at_quantiles");
-        scalar.add("qdigest_agg");
         scalar.add("value_at_quantile");
         SCALAR_FUNCTIONS = Collections.unmodifiableSet(scalar);
 

--- a/src/main/java/io/github/yuokada/core/UdfCatalog.java
+++ b/src/main/java/io/github/yuokada/core/UdfCatalog.java
@@ -31,6 +31,11 @@ public final class UdfCatalog {
     }
 
     /**
+     * Shared YAML-capable mapper; instantiated once to avoid per-call allocation overhead.
+     */
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    /**
      * Root element of the YAML document.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -52,8 +57,7 @@ public final class UdfCatalog {
      * @throws IOException if the file cannot be read or parsed
      */
     public static Map<String, UdfDefinition> load(Path path) throws IOException {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        Root root = mapper.readValue(path.toFile(), Root.class);
+        Root root = YAML_MAPPER.readValue(path.toFile(), Root.class);
         if (root == null || root.functions == null) {
             return Collections.emptyMap();
         }

--- a/src/main/java/io/github/yuokada/core/UdfCatalog.java
+++ b/src/main/java/io/github/yuokada/core/UdfCatalog.java
@@ -1,0 +1,68 @@
+package io.github.yuokada.core;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads a YAML UDF catalog file and provides a map of function definitions.
+ *
+ * <p>Expected YAML format:
+ * <pre>{@code
+ * functions:
+ *   - name: my_etl_transform
+ *     description: "ETL transformation function"
+ *     arity: 2
+ *   - name: my_variadic_udf
+ *     minArgs: 1
+ * }</pre>
+ *
+ * <p>Function names are stored in lowercase for case-insensitive lookup.
+ */
+public final class UdfCatalog {
+
+    private UdfCatalog() {
+    }
+
+    /**
+     * Root element of the YAML document.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class Root {
+        /**
+         * List of UDF definitions.
+         */
+        public List<UdfDefinition> functions;
+    }
+
+    /**
+     * Loads and parses a YAML UDF catalog file.
+     *
+     * <p>Lines starting with {@code #} are treated as YAML comments and ignored.
+     * Function names in the returned map are normalized to lowercase.
+     *
+     * @param path path to the YAML file (UTF-8 encoded)
+     * @return unmodifiable map from lowercase function name to its definition
+     * @throws IOException if the file cannot be read or parsed
+     */
+    public static Map<String, UdfDefinition> load(Path path) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        Root root = mapper.readValue(path.toFile(), Root.class);
+        if (root == null || root.functions == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, UdfDefinition> result = new LinkedHashMap<>();
+        for (UdfDefinition def : root.functions) {
+            if (def != null && def.name != null && !def.name.isBlank()) {
+                result.put(def.name.toLowerCase(), def);
+            }
+        }
+        return Collections.unmodifiableMap(result);
+    }
+}

--- a/src/main/java/io/github/yuokada/core/UdfDefinition.java
+++ b/src/main/java/io/github/yuokada/core/UdfDefinition.java
@@ -1,0 +1,103 @@
+package io.github.yuokada.core;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents a single UDF entry loaded from a YAML UDF catalog file.
+ *
+ * <p>A definition may specify arity constraints in one of the following ways:
+ * <ul>
+ *   <li>{@code arity} — exact argument count. Takes precedence over {@code minArgs}/{@code maxArgs}.
+ *   </li>
+ *   <li>{@code minArgs} / {@code maxArgs} — lower and/or upper bound on argument count.</li>
+ *   <li>Neither — the function is considered "known" but no arity check is performed (W003
+ *       is never emitted for this function).</li>
+ * </ul>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UdfDefinition {
+
+    /**
+     * Function name (case-insensitive; stored in original case from YAML).
+     */
+    public String name;
+
+    /**
+     * Optional description (not used for validation).
+     */
+    public String description;
+
+    /**
+     * Exact expected argument count. When non-null, takes precedence over
+     * {@code minArgs} and {@code maxArgs}.
+     */
+    public Integer arity;
+
+    /**
+     * Minimum number of arguments (inclusive). Ignored when {@code arity} is non-null.
+     */
+    public Integer minArgs;
+
+    /**
+     * Maximum number of arguments (inclusive). {@code null} means no upper bound.
+     * Ignored when {@code arity} is non-null.
+     */
+    public Integer maxArgs;
+
+    /**
+     * Returns a human-readable description of the expected argument count.
+     *
+     * <p>Examples: {@code "2"}, {@code "at least 1"}, {@code "between 2 and 4"}.
+     * Returns {@code null} when no arity constraint is defined.
+     *
+     * @return arity description string, or {@code null} if unconstrained
+     */
+    public String expectedArityDescription() {
+        if (this.arity != null) {
+            return String.valueOf(this.arity);
+        }
+        if (this.minArgs != null && this.maxArgs != null) {
+            return "between " + this.minArgs + " and " + this.maxArgs;
+        }
+        if (this.minArgs != null) {
+            return "at least " + this.minArgs;
+        }
+        if (this.maxArgs != null) {
+            return "at most " + this.maxArgs;
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} when the given actual argument count satisfies this definition's
+     * arity constraints.
+     *
+     * <p>When no constraint is defined (all fields are {@code null}), this method always
+     * returns {@code true} (no arity check performed).
+     *
+     * @param actualArgs the number of arguments in the function call
+     * @return {@code true} when arity is valid, {@code false} on mismatch
+     */
+    public boolean isArityValid(int actualArgs) {
+        if (this.arity != null) {
+            return actualArgs == this.arity;
+        }
+        if (this.minArgs != null && actualArgs < this.minArgs) {
+            return false;
+        }
+        if (this.maxArgs != null && actualArgs > this.maxArgs) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code true} when this definition specifies at least one arity constraint
+     * ({@code arity}, {@code minArgs}, or {@code maxArgs}).
+     *
+     * @return {@code true} if an arity check should be performed
+     */
+    public boolean hasArityConstraint() {
+        return this.arity != null || this.minArgs != null || this.maxArgs != null;
+    }
+}

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -11,8 +11,12 @@ import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.output.TextAnalysisPrinter;
 import io.github.yuokada.subcommand.util.SqlInput;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
@@ -21,8 +25,10 @@ import picocli.CommandLine.ParentCommand;
 
 @CommandLine.Command(name = "analyze", description = "Analyze SQL query")
 public class Analyze implements Callable<Integer> {
+    /** Error message emitted when more than one statement is supplied. */
     private static final String MULTIPLE_STATEMENTS_ERROR_MESSAGE =
         "analyze supports exactly one query; found multiple statements";
+    /** Exit code returned when more than one statement is supplied. */
     private static final int MULTIPLE_STATEMENTS_EXIT_CODE = 1;
 
     /**
@@ -106,6 +112,22 @@ public class Analyze implements Callable<Integer> {
         description = "Maximum AST depth to display. 0 = unlimited.")
     private int astDepth;
 
+    /**
+     * When true, unknown functions (not Trino built-ins) are flagged as W002 lint findings.
+     */
+    @CommandLine.Option(names = {"--validate-functions"}, defaultValue = "false",
+        description = "Flag unknown functions (not Trino built-ins) as W002 lint warnings.")
+    private boolean validateFunctions;
+
+    /**
+     * Comma-separated list of additional known function names, or {@code @<file>} to load from
+     * a UTF-8 text file (one name per line; empty lines and lines starting with '#' are ignored).
+     * Only effective when {@code --validate-functions} is also set.
+     */
+    @CommandLine.Option(names = {"--known-functions"},
+        description = "Extra known function names (comma-separated or @file).")
+    private String knownFunctionsInput;
+
     @Override
     public Integer call() throws IOException {
         AstView view;
@@ -126,6 +148,8 @@ public class Analyze implements Callable<Integer> {
             return ExitCode.OK;
         }
 
+        Set<String> knownFunctions = parseKnownFunctions(this.knownFunctionsInput);
+
         String statement = statements.get(0);
         try (OutputEmitter emitter = new OutputEmitter(outputPath);
             AnalysisPrinter printer = isJsonFormat()
@@ -133,11 +157,50 @@ public class Analyze implements Callable<Integer> {
                     view, this.astDepth)
                 : new TextAnalysisPrinter(emitter, isFullDetails(), showAst, view,
                     this.astDepth)) {
-            QueryAnalysisResult result =
-                QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema);
+            QueryAnalysisResult result = this.validateFunctions
+                ? QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema, knownFunctions)
+                : QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema);
             printer.printStatement(result, null, statement);
         }
         return ExitCode.OK;
+    }
+
+    /**
+     * Parses the {@code --known-functions} input into a set of lowercase function names.
+     *
+     * <p>Accepts:
+     * <ul>
+     *   <li>Comma-separated list: {@code "my_udf,another_udf"}</li>
+     *   <li>File reference: {@code "@/path/to/udfs.txt"} — one name per line,
+     *       empty lines and lines starting with {@code #} are ignored.</li>
+     * </ul>
+     *
+     * @param input raw option value (may be null)
+     * @return parsed set of lowercase function names (never null)
+     * @throws IOException if a referenced file cannot be read
+     */
+    private static Set<String> parseKnownFunctions(String input) throws IOException {
+        Set<String> result = new HashSet<>();
+        if (input == null || input.isBlank()) {
+            return result;
+        }
+        if (input.startsWith("@")) {
+            Path filePath = Path.of(input.substring(1));
+            for (String line : Files.readAllLines(filePath)) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+                    result.add(trimmed.toLowerCase());
+                }
+            }
+        } else {
+            for (String part : input.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    result.add(trimmed.toLowerCase());
+                }
+            }
+        }
+        return result;
     }
 
     private List<String> collectStatements() throws IOException {
@@ -218,5 +281,13 @@ public class Analyze implements Callable<Integer> {
 
     void setAstDepth(int astDepth) {
         this.astDepth = astDepth;
+    }
+
+    void setValidateFunctions(boolean validateFunctions) {
+        this.validateFunctions = validateFunctions;
+    }
+
+    void setKnownFunctionsInput(String knownFunctionsInput) {
+        this.knownFunctionsInput = knownFunctionsInput;
     }
 }

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -13,6 +13,7 @@ import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.output.TextAnalysisPrinter;
 import io.github.yuokada.subcommand.util.SqlInput;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -223,7 +224,7 @@ public class Analyze implements Callable<Integer> {
         }
         if (input.startsWith("@")) {
             Path filePath = Path.of(input.substring(1));
-            for (String line : Files.readAllLines(filePath)) {
+            for (String line : Files.readAllLines(filePath, StandardCharsets.UTF_8)) {
                 String trimmed = line.trim();
                 if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
                     result.add(trimmed.toLowerCase());

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -5,6 +5,8 @@ import io.github.yuokada.core.AstView;
 import io.github.yuokada.core.ExitCodes;
 import io.github.yuokada.core.QueryAnalysisResult;
 import io.github.yuokada.core.QueryAnalyzer;
+import io.github.yuokada.core.UdfCatalog;
+import io.github.yuokada.core.UdfDefinition;
 import io.github.yuokada.subcommand.output.AnalysisPrinter;
 import io.github.yuokada.subcommand.output.JsonAnalysisPrinter;
 import io.github.yuokada.subcommand.output.OutputEmitter;
@@ -16,6 +18,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -128,6 +131,15 @@ public class Analyze implements Callable<Integer> {
         description = "Extra known function names (comma-separated or @file).")
     private String knownFunctionsInput;
 
+    /**
+     * Path to a YAML file containing UDF definitions for arity validation (W003).
+     * Functions listed in the catalog are also treated as "known" when
+     * {@code --validate-functions} is enabled, suppressing W002 for them.
+     */
+    @CommandLine.Option(names = {"--udf-catalog"},
+        description = "YAML file with UDF definitions for arity validation (W003).")
+    private String udfCatalogPath;
+
     @Override
     public Integer call() throws IOException {
         AstView view;
@@ -148,7 +160,18 @@ public class Analyze implements Callable<Integer> {
             return ExitCode.OK;
         }
 
-        Set<String> knownFunctions = parseKnownFunctions(this.knownFunctionsInput);
+        Map<String, UdfDefinition> udfCatalog = loadUdfCatalog(this.udfCatalogPath);
+
+        // Build the effective known-functions set.
+        // null means W002 is disabled; non-null enables W002 for unrecognized functions.
+        Set<String> effectiveKnown = null;
+        if (this.validateFunctions) {
+            effectiveKnown = parseKnownFunctions(this.knownFunctionsInput);
+            // Functions in the UDF catalog are always treated as known (no W002).
+            if (udfCatalog != null) {
+                effectiveKnown.addAll(udfCatalog.keySet());
+            }
+        }
 
         String statement = statements.get(0);
         try (OutputEmitter emitter = new OutputEmitter(outputPath);
@@ -157,12 +180,26 @@ public class Analyze implements Callable<Integer> {
                     view, this.astDepth)
                 : new TextAnalysisPrinter(emitter, isFullDetails(), showAst, view,
                     this.astDepth)) {
-            QueryAnalysisResult result = this.validateFunctions
-                ? QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema, knownFunctions)
-                : QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema);
+            QueryAnalysisResult result =
+                QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema,
+                    effectiveKnown, udfCatalog);
             printer.printStatement(result, null, statement);
         }
         return ExitCode.OK;
+    }
+
+    /**
+     * Loads the UDF catalog from the given YAML file path.
+     *
+     * @param path raw option value (may be null or blank)
+     * @return parsed UDF catalog map, or {@code null} when no path is specified
+     * @throws IOException if the file cannot be read or is not valid YAML
+     */
+    private static Map<String, UdfDefinition> loadUdfCatalog(String path) throws IOException {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        return UdfCatalog.load(Path.of(path));
     }
 
     /**
@@ -289,5 +326,9 @@ public class Analyze implements Callable<Integer> {
 
     void setKnownFunctionsInput(String knownFunctionsInput) {
         this.knownFunctionsInput = knownFunctionsInput;
+    }
+
+    void setUdfCatalogPath(String udfCatalogPath) {
+        this.udfCatalogPath = udfCatalogPath;
     }
 }

--- a/src/main/java/io/github/yuokada/subcommand/output/TextAnalysisPrinter.java
+++ b/src/main/java/io/github/yuokada/subcommand/output/TextAnalysisPrinter.java
@@ -111,6 +111,10 @@ public final class TextAnalysisPrinter implements AnalysisPrinter {
                 String.join(",", r.getFunctionsWindow().stream().sorted().toList())
             ));
         }
+        if (!r.getUnknownFunctions().isEmpty()) {
+            emitter.emit(String.format("UnknownFunctions: [%s]",
+                String.join(",", r.getUnknownFunctions().stream().sorted().toList())));
+        }
         if (!r.getWriteTargets().isEmpty()) {
             emitter.emit(
                 String.format("WriteTargets: [%s]",

--- a/src/test/java/io/github/yuokada/core/TrinoBuiltinFunctionsTest.java
+++ b/src/test/java/io/github/yuokada/core/TrinoBuiltinFunctionsTest.java
@@ -1,0 +1,121 @@
+package io.github.yuokada.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TrinoBuiltinFunctions}.
+ */
+class TrinoBuiltinFunctionsTest {
+
+    @Test
+    void testAggregatesAreBuiltin() {
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("count"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("sum"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("avg"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("min"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("max"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("approx_distinct"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("array_agg"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("map_agg"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("stddev"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("count_if"));
+    }
+
+    @Test
+    void testWindowFunctionsAreBuiltin() {
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("row_number"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("rank"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("dense_rank"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("lead"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("lag"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("first_value"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("last_value"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("nth_value"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("ntile"));
+    }
+
+    @Test
+    void testScalarFunctionsAreBuiltin() {
+        // Math
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("abs"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("sqrt"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("round"));
+        // String
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("lower"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("upper"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("length"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("substr"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("concat"));
+        // Date/time
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("now"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("date_trunc"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("date_format"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("from_unixtime"));
+        // Array
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("cardinality"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("array_sort"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("filter"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("transform"));
+        // Map
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("map_keys"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("map_values"));
+        // JSON
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("json_extract_scalar"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("json_parse"));
+        // Conditional
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("coalesce"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("try"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("try_cast"));
+        // Regex
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("regexp_like"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("regexp_extract"));
+    }
+
+    @Test
+    void testCaseInsensitive() {
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("COUNT"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("Count"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("LOWER"));
+        assertTrue(TrinoBuiltinFunctions.isBuiltin("Row_Number"));
+    }
+
+    @Test
+    void testCustomUdfIsNotBuiltin() {
+        assertFalse(TrinoBuiltinFunctions.isBuiltin("my_custom_udf"));
+        assertFalse(TrinoBuiltinFunctions.isBuiltin("td_time_format"));
+        assertFalse(TrinoBuiltinFunctions.isBuiltin("date_to_epoch"));
+        assertFalse(TrinoBuiltinFunctions.isBuiltin("my_etl_transform"));
+    }
+
+    @Test
+    void testNullAndEmptyReturnFalse() {
+        assertFalse(TrinoBuiltinFunctions.isBuiltin(null));
+        assertFalse(TrinoBuiltinFunctions.isAggregate(null));
+        assertFalse(TrinoBuiltinFunctions.isWindow(null));
+    }
+
+    @Test
+    void testIsAggregateCategory() {
+        assertTrue(TrinoBuiltinFunctions.isAggregate("count"));
+        assertTrue(TrinoBuiltinFunctions.isAggregate("stddev_pop"));
+        assertFalse(TrinoBuiltinFunctions.isAggregate("lower"));
+        assertFalse(TrinoBuiltinFunctions.isAggregate("row_number"));
+    }
+
+    @Test
+    void testIsWindowCategory() {
+        assertTrue(TrinoBuiltinFunctions.isWindow("row_number"));
+        assertTrue(TrinoBuiltinFunctions.isWindow("lag"));
+        assertFalse(TrinoBuiltinFunctions.isWindow("count"));
+        assertFalse(TrinoBuiltinFunctions.isWindow("lower"));
+    }
+
+    @Test
+    void testAllBuiltinsIsNonEmpty() {
+        assertFalse(TrinoBuiltinFunctions.allBuiltins().isEmpty(),
+            "Built-in catalog should not be empty");
+    }
+}

--- a/src/test/java/io/github/yuokada/core/UdfCatalogTest.java
+++ b/src/test/java/io/github/yuokada/core/UdfCatalogTest.java
@@ -1,0 +1,211 @@
+package io.github.yuokada.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link UdfCatalog} YAML loading and {@link UdfDefinition} arity logic.
+ */
+class UdfCatalogTest {
+
+    // ---- YAML loading -------------------------------------------------------
+
+    @Test
+    void testLoad_exactArity(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 2\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        assertEquals(1, catalog.size());
+        assertTrue(catalog.containsKey("my_fn"));
+        assertEquals(2, catalog.get("my_fn").arity);
+        assertNull(catalog.get("my_fn").minArgs);
+    }
+
+    @Test
+    void testLoad_minArgs(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: variadic_fn\n    minArgs: 1\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        UdfDefinition def = catalog.get("variadic_fn");
+        assertNotNull(def);
+        assertNull(def.arity);
+        assertEquals(1, def.minArgs);
+        assertNull(def.maxArgs);
+    }
+
+    @Test
+    void testLoad_minAndMaxArgs(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml,
+            "functions:\n  - name: bounded_fn\n    minArgs: 2\n    maxArgs: 4\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        UdfDefinition def = catalog.get("bounded_fn");
+        assertNotNull(def);
+        assertEquals(2, def.minArgs);
+        assertEquals(4, def.maxArgs);
+    }
+
+    @Test
+    void testLoad_noArityConstraint(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml,
+            "functions:\n  - name: unconstrained_fn\n    description: \"known UDF\"\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        UdfDefinition def = catalog.get("unconstrained_fn");
+        assertNotNull(def);
+        assertFalse(def.hasArityConstraint(), "Should have no arity constraint");
+    }
+
+    @Test
+    void testLoad_keyIsLowercase(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: My_ETL_Transform\n    arity: 1\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        assertTrue(catalog.containsKey("my_etl_transform"),
+            "Key must be lowercased");
+        assertFalse(catalog.containsKey("My_ETL_Transform"),
+            "Original-case key must not be present");
+    }
+
+    @Test
+    void testLoad_multipleEntries(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml,
+            "functions:\n"
+                + "  - name: fn_a\n    arity: 1\n"
+                + "  - name: fn_b\n    minArgs: 2\n"
+                + "  - name: fn_c\n    description: \"no arity\"\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+
+        assertEquals(3, catalog.size());
+        assertEquals(1, catalog.get("fn_a").arity);
+        assertEquals(2, catalog.get("fn_b").minArgs);
+        assertFalse(catalog.get("fn_c").hasArityConstraint());
+    }
+
+    @Test
+    void testLoad_yamlComment(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml,
+            "# Project UDFs\n"
+                + "functions:\n"
+                + "  - name: my_fn  # inline comment\n"
+                + "    arity: 3\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+        assertEquals(1, catalog.size());
+        assertEquals(3, catalog.get("my_fn").arity);
+    }
+
+    @Test
+    void testLoad_emptyFile(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n");
+
+        Map<String, UdfDefinition> catalog = UdfCatalog.load(yaml);
+        assertTrue(catalog.isEmpty(), "Empty functions list should produce empty map");
+    }
+
+    // ---- UdfDefinition arity logic ------------------------------------------
+
+    @Test
+    void testIsArityValid_exactMatch() {
+        UdfDefinition def = new UdfDefinition();
+        def.arity = 2;
+        assertTrue(def.isArityValid(2));
+        assertFalse(def.isArityValid(1));
+        assertFalse(def.isArityValid(3));
+    }
+
+    @Test
+    void testIsArityValid_minOnly() {
+        UdfDefinition def = new UdfDefinition();
+        def.minArgs = 1;
+        assertTrue(def.isArityValid(1));
+        assertTrue(def.isArityValid(5));
+        assertFalse(def.isArityValid(0));
+    }
+
+    @Test
+    void testIsArityValid_minAndMax() {
+        UdfDefinition def = new UdfDefinition();
+        def.minArgs = 2;
+        def.maxArgs = 4;
+        assertFalse(def.isArityValid(1));
+        assertTrue(def.isArityValid(2));
+        assertTrue(def.isArityValid(4));
+        assertFalse(def.isArityValid(5));
+    }
+
+    @Test
+    void testIsArityValid_noConstraint() {
+        UdfDefinition def = new UdfDefinition();
+        // All calls are valid when no constraint is set
+        assertTrue(def.isArityValid(0));
+        assertTrue(def.isArityValid(100));
+    }
+
+    @Test
+    void testExpectedArityDescription_exact() {
+        UdfDefinition def = new UdfDefinition();
+        def.arity = 3;
+        assertEquals("3", def.expectedArityDescription());
+    }
+
+    @Test
+    void testExpectedArityDescription_minOnly() {
+        UdfDefinition def = new UdfDefinition();
+        def.minArgs = 1;
+        assertEquals("at least 1", def.expectedArityDescription());
+    }
+
+    @Test
+    void testExpectedArityDescription_maxOnly() {
+        UdfDefinition def = new UdfDefinition();
+        def.maxArgs = 5;
+        assertEquals("at most 5", def.expectedArityDescription());
+    }
+
+    @Test
+    void testExpectedArityDescription_minAndMax() {
+        UdfDefinition def = new UdfDefinition();
+        def.minArgs = 2;
+        def.maxArgs = 4;
+        assertEquals("between 2 and 4", def.expectedArityDescription());
+    }
+
+    @Test
+    void testExpectedArityDescription_noConstraint() {
+        UdfDefinition def = new UdfDefinition();
+        assertNull(def.expectedArityDescription(), "No constraint should return null");
+    }
+
+    @Test
+    void testHasArityConstraint() {
+        UdfDefinition def = new UdfDefinition();
+        assertFalse(def.hasArityConstraint());
+        def.arity = 1;
+        assertTrue(def.hasArityConstraint());
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeUdfCatalogTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeUdfCatalogTest.java
@@ -1,0 +1,279 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests for the {@code --udf-catalog} option and W003 lint rule.
+ */
+class AnalyzeUdfCatalogTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    // ---- W003 not triggered without --udf-catalog ---------------------------
+
+    @Test
+    void testNoW003_withoutUdfCatalog(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a, b) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W003"),
+            "W003 should not appear without --udf-catalog: " + out);
+    }
+
+    // ---- W003 triggered on arity mismatch -----------------------------------
+
+    @Test
+    void testW003_arityMismatch_exactArity(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a) FROM t;");  // expects 2, got 1
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("W003"), "W003 should appear on arity mismatch: " + out);
+        assertTrue(out.contains("my_fn"), "Function name should appear: " + out);
+        assertTrue(out.contains("expects 2"), "Expected arity should appear: " + out);
+        assertTrue(out.contains("got 1"), "Actual arity should appear: " + out);
+    }
+
+    // ---- W003 not triggered when arity matches -------------------------------
+
+    @Test
+    void testNoW003_arityCorrect(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a, b) FROM t;");  // correct: 2 args
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W003"), "No W003 when arity is correct: " + out);
+    }
+
+    // ---- W003 with minArgs ---------------------------------------------------
+
+    @Test
+    void testW003_minArgsViolation(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: variadic\n    minArgs: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT variadic(a) FROM t;");  // expects >= 2, got 1
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("W003"), "W003 should appear for minArgs violation: " + out);
+        assertTrue(out.contains("at least 2"), "Expected description should appear: " + out);
+    }
+
+    // ---- W003 with no arity constraint: no finding --------------------------
+
+    @Test
+    void testNoW003_unconstrained(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml,
+            "functions:\n  - name: my_fn\n    description: \"known but unconstrained\"\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a, b, c, d) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W003"), "No W003 for unconstrained function: " + out);
+    }
+
+    // ---- udf-catalog functions are treated as known (no W002) ---------------
+
+    @Test
+    void testUdfCatalog_suppressesW002(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 1\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a) FROM t;");  // correct arity
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        // my_fn is in the catalog → should not generate W002
+        assertFalse(out.contains("W002"),
+            "Catalog function should not produce W002: " + out);
+        // Arity matches → no W003 either
+        assertFalse(out.contains("W003"),
+            "No W003 when arity matches: " + out);
+    }
+
+    // ---- W002 for unknown + W003 for catalog function with wrong arity ------
+
+    @Test
+    void testBothW002andW003(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: catalog_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        // catalog_fn called with wrong arity → W003
+        // unknown_fn not in catalog and --validate-functions → W002
+        Files.writeString(sql, "SELECT catalog_fn(a), unknown_fn(x) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("W002"), "W002 should appear for unknown_fn: " + out);
+        assertTrue(out.contains("W003"), "W003 should appear for catalog_fn arity mismatch: " + out);
+        assertTrue(out.contains("unknown_fn"), "unknown_fn should appear: " + out);
+        assertTrue(out.contains("catalog_fn"), "catalog_fn should appear: " + out);
+    }
+
+    // ---- udf-catalog only (no --validate-functions): only W003 --------------
+
+    @Test
+    void testUdfCatalogOnly_noW002(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: catalog_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        // another_fn is not in catalog, but --validate-functions is not set → no W002
+        // catalog_fn has wrong arity → W003
+        Files.writeString(sql, "SELECT catalog_fn(a), another_fn(x) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        // validateFunctions NOT set
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"), "No W002 without --validate-functions: " + out);
+        assertTrue(out.contains("W003"), "W003 for arity mismatch: " + out);
+    }
+
+    // ---- Exit code is OK even when W003 is triggered -----------------------
+
+    @Test
+    void testExitCode_isOkEvenWithW003(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 3\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        int exitCode = analyze.call();
+
+        assertEquals(0, exitCode, "Analyze should exit OK even with W003 findings");
+    }
+
+    // ---- Text output includes W003 in Lint line -----------------------------
+
+    @Test
+    void testTextOutput_w003InLintLine(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: my_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_fn(a) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("text");
+        analyze.setDetails("full");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("Lint:"), "Lint line should appear: " + out);
+        assertTrue(out.contains("W003"), "W003 should appear in text Lint line: " + out);
+        assertTrue(out.contains("my_fn"), "Function name should appear: " + out);
+    }
+
+    // ---- Function not in catalog: no W003 -----------------------------------
+
+    @Test
+    void testNoW003_functionNotInCatalog(@TempDir Path tempDir) throws IOException {
+        Path yaml = tempDir.resolve("udfs.yaml");
+        Files.writeString(yaml, "functions:\n  - name: catalog_fn\n    arity: 2\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT other_fn(a, b, c) FROM t;");  // other_fn not in catalog
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setUdfCatalogPath(yaml.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W003"), "No W003 for function not in catalog: " + out);
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeUdfCatalogTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeUdfCatalogTest.java
@@ -47,6 +47,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.call();
 
         String out = outContent.toString(StandardCharsets.UTF_8);
@@ -67,6 +68,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 
@@ -90,6 +92,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 
@@ -110,6 +113,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 
@@ -132,6 +136,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 
@@ -152,6 +157,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
@@ -180,13 +186,15 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 
         String out = outContent.toString(StandardCharsets.UTF_8);
         assertTrue(out.contains("W002"), "W002 should appear for unknown_fn: " + out);
-        assertTrue(out.contains("W003"), "W003 should appear for catalog_fn arity mismatch: " + out);
+        assertTrue(out.contains("W003"),
+            "W003 should appear for catalog_fn arity mismatch: " + out);
         assertTrue(out.contains("unknown_fn"), "unknown_fn should appear: " + out);
         assertTrue(out.contains("catalog_fn"), "catalog_fn should appear: " + out);
     }
@@ -206,6 +214,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         // validateFunctions NOT set
         analyze.call();
@@ -228,6 +237,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         int exitCode = analyze.call();
 
@@ -270,6 +280,7 @@ class AnalyzeUdfCatalogTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setUdfCatalogPath(yaml.toString());
         analyze.call();
 

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeValidateFunctionsTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeValidateFunctionsTest.java
@@ -48,6 +48,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.call();
 
         String out = outContent.toString(StandardCharsets.UTF_8);
@@ -70,6 +71,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.call();
 
@@ -89,6 +91,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.call();
 
@@ -109,6 +112,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.setKnownFunctionsInput("my_etl_transform,another_udf");
         analyze.call();
@@ -128,6 +132,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.setKnownFunctionsInput("known_udf");
         analyze.call();
@@ -156,6 +161,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.setKnownFunctionsInput("@" + udfFile.toString());
         analyze.call();
@@ -201,6 +207,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.call();
 
@@ -220,6 +227,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         analyze.call();
 
@@ -228,8 +236,6 @@ class AnalyzeValidateFunctionsTest {
         assertTrue(out.contains("udf_a"), "udf_a should appear: " + out);
         assertTrue(out.contains("udf_b"), "udf_b should appear: " + out);
         // Two W002 findings expected
-        long w002count = out.chars().filter(c -> c == '2')
-            .count(); // rough check — both appear in output
         assertTrue(out.indexOf("W002") != out.lastIndexOf("W002"),
             "Two W002 findings expected (one per unknown function): " + out);
     }
@@ -244,6 +250,7 @@ class AnalyzeValidateFunctionsTest {
         Analyze analyze = new Analyze();
         analyze.setSqlFile(sql.toString());
         analyze.setFormat("json");
+        analyze.setDetails("full");
         analyze.setValidateFunctions(true);
         int exitCode = analyze.call();
 

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeValidateFunctionsTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeValidateFunctionsTest.java
@@ -1,0 +1,252 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests for the {@code --validate-functions} and {@code --known-functions} options
+ * on the {@code analyze} subcommand.
+ */
+class AnalyzeValidateFunctionsTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    // ---- W002 not triggered without --validate-functions ----------------------
+
+    @Test
+    void testNoValidation_noW002(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_custom_udf(id) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"),
+            "W002 should not appear without --validate-functions: " + out);
+        assertTrue(out.contains("unknownFunctions"),
+            "unknownFunctions array should always appear in JSON");
+        // Without validation the unknownFunctions array should be empty
+        assertTrue(out.contains("\"unknownFunctions\":[]"),
+            "unknownFunctions should be empty without --validate-functions: " + out);
+    }
+
+    // ---- W002 triggered for unknown function ----------------------------------
+
+    @Test
+    void testValidation_unknownFunctionProducesW002(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_custom_udf(id) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("W002"), "W002 should appear for unknown function: " + out);
+        assertTrue(out.contains("my_custom_udf"),
+            "Unknown function name should appear in output: " + out);
+    }
+
+    // ---- Known Trino built-in does not trigger W002 --------------------------
+
+    @Test
+    void testValidation_builtinFunctionNoW002(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT COUNT(*), LOWER(name) FROM t GROUP BY name;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"),
+            "Built-in functions should not trigger W002: " + out);
+        assertTrue(out.contains("\"unknownFunctions\":[]"),
+            "unknownFunctions should be empty for built-ins: " + out);
+    }
+
+    // ---- --known-functions (comma-separated) suppresses W002 ----------------
+
+    @Test
+    void testKnownFunctions_commaList_suppressesW002(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_etl_transform(id), another_udf(name) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.setKnownFunctionsInput("my_etl_transform,another_udf");
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"),
+            "Declared known functions should not produce W002: " + out);
+    }
+
+    // ---- --known-functions partially suppresses W002 -------------------------
+
+    @Test
+    void testKnownFunctions_partialMatch(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT known_udf(id), unknown_udf(name) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.setKnownFunctionsInput("known_udf");
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        // unknown_udf is not declared → should appear in findings
+        assertTrue(out.contains("W002"), "unknown_udf should still produce W002: " + out);
+        assertTrue(out.contains("unknown_udf"), "unknown_udf should appear in output: " + out);
+        // known_udf is declared → should not be in unknownFunctions
+        assertFalse(out.contains("\"unknownFunctions\":[\"known_udf\"]"),
+            "known_udf should not appear in unknownFunctions: " + out);
+        assertFalse(out.contains("Unknown function: known_udf"),
+            "known_udf should not produce a W002 message: " + out);
+    }
+
+    // ---- --known-functions via @file -----------------------------------------
+
+    @Test
+    void testKnownFunctions_atFile_suppressesW002(@TempDir Path tempDir) throws IOException {
+        Path udfFile = tempDir.resolve("udfs.txt");
+        Files.writeString(udfFile, "# My project UDFs\nmy_etl_transform\n\nanother_udf\n");
+
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_etl_transform(id) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.setKnownFunctionsInput("@" + udfFile.toString());
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"),
+            "Function declared in @file should not produce W002: " + out);
+    }
+
+    // ---- Text output includes UnknownFunctions line --------------------------
+
+    @Test
+    void testTextOutput_unknownFunctions_line(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_custom_udf(id) FROM catalog1.s.t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("text");
+        analyze.setDetails("full");
+        analyze.setValidateFunctions(true);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("UnknownFunctions:"),
+            "Text output should contain UnknownFunctions line: " + out);
+        assertTrue(out.contains("my_custom_udf"),
+            "Unknown function name should appear in text output: " + out);
+        assertTrue(out.contains("Lint:"),
+            "Lint line should appear: " + out);
+        assertTrue(out.contains("W002"),
+            "W002 should appear in text lint output: " + out);
+    }
+
+    // ---- Case-insensitive matching -------------------------------------------
+
+    @Test
+    void testValidation_caseInsensitive(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        // COUNT is a Trino built-in (uppercase in SQL)
+        Files.writeString(sql, "SELECT COUNT(*) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("W002"),
+            "COUNT (uppercase) is a built-in and should not trigger W002: " + out);
+    }
+
+    // ---- Multiple unknown functions -------------------------------------------
+
+    @Test
+    void testMultipleUnknownFunctions(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql,
+            "SELECT udf_a(id), udf_b(name), COUNT(*) FROM t GROUP BY id, name;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        // Both udf_a and udf_b should appear; COUNT should not
+        assertTrue(out.contains("udf_a"), "udf_a should appear: " + out);
+        assertTrue(out.contains("udf_b"), "udf_b should appear: " + out);
+        // Two W002 findings expected
+        long w002count = out.chars().filter(c -> c == '2')
+            .count(); // rough check — both appear in output
+        assertTrue(out.indexOf("W002") != out.lastIndexOf("W002"),
+            "Two W002 findings expected (one per unknown function): " + out);
+    }
+
+    // ---- Exit code is OK even when W002 is triggered -------------------------
+
+    @Test
+    void testExitCode_isOkEvenWithW002(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT my_udf(id) FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setValidateFunctions(true);
+        int exitCode = analyze.call();
+
+        assertEquals(0, exitCode, "Analyze should exit OK even with W002 findings");
+    }
+}


### PR DESCRIPTION
## Summary

Full UDF validation feature for the `analyze` subcommand:

- **W002** (`--validate-functions`): flags function calls not found in the Trino built-in catalog
- **W003** (`--udf-catalog`): flags function calls whose argument count does not match a YAML-defined UDF signature

## New components

| Component | Description |
|---|---|
| `TrinoBuiltinFunctions` | Catalog of ~200 Trino 435 built-in functions (scalar/aggregate/window) |
| `UdfDefinition` | POJO: `arity`, `minArgs`, `maxArgs`, `description` |
| `UdfCatalog` | Loads a YAML file via `jackson-dataformat-yaml`; returns lowercase-keyed map |
| `QueryAnalyzer.analyze()` | New 4-arg and 5-arg overloads for validation |
| `QueryAnalysisResult` | `unknownFunctions` set, `w003Findings` list, W002/W003 in `getFindings()` |

## Options added to `analyze`

| Option | Effect |
|---|---|
| `--validate-functions` | Emit W002 for functions not in Trino built-in catalog |
| `--known-functions <list\|@file>` | Suppress W002 for declared UDFs |
| `--udf-catalog <yaml>` | Emit W003 for arity mismatches; catalog functions are treated as known |

## YAML format (`--udf-catalog`)

```yaml
functions:
  - name: my_etl_transform
    arity: 2
  - name: my_variadic_udf
    minArgs: 1
  - name: bounded_fn
    minArgs: 2
    maxArgs: 4
  - name: known_no_arity  # treated as known, no arity check
    description: "Custom UDF"
```

## Usage examples

```bash
# W002 only
analyze --validate-functions query.sql

# W002 with known UDFs
analyze --validate-functions --known-functions "my_udf,other_udf" query.sql
analyze --validate-functions --known-functions @udfs.txt query.sql

# W003 only (no W002)
analyze --udf-catalog udfs.yaml query.sql

# Both W002 and W003
analyze --validate-functions --udf-catalog udfs.yaml query.sql
```

## Test plan

- [x] `TrinoBuiltinFunctionsTest` — 9 tests: built-in catalog correctness
- [x] `AnalyzeValidateFunctionsTest` — 10 tests: E2E W002 tests
- [x] `UdfCatalogTest` — 18 tests: YAML loading and arity logic
- [x] `AnalyzeUdfCatalogTest` — 11 tests: E2E W003 tests
- [x] All 182 tests pass (`./mvnw verify`)
- [x] Checkstyle clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)