### PR TITLE
Add Phase 2 remote validation via EXPLAIN (TYPE VALIDATE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ analyze [options] [<file>]
 | `--validate-functions` | false | Flag functions that are not Trino built-ins as **W002** lint warnings. |
 | `--known-functions <list\|@file>` | — | Comma-separated list of additional known function names, or `@path` to a text file (one name per line). Requires `--validate-functions`. |
 | `--udf-catalog <path>` | — | YAML file with UDF definitions for arity validation (**W003**). Functions listed are also treated as known (suppresses W002). |
+| `--server <host:port>` | — | Trino server for Phase 2 remote validation via `EXPLAIN (TYPE VALIDATE)`. Omit to run local analysis only. |
+| `--server-user <name>` | OS user | User name for the Trino session. Falls back to `TRINO_USER` env var. |
+| `--server-password` | — | Password for Basic auth. Omit the value to be prompted interactively. Falls back to `TRINO_PASSWORD`. |
+| `--server-access-token <token>` | — | Bearer token for OAuth2/JWT. Falls back to `TRINO_ACCESS_TOKEN`. |
+| `--server-ssl` | false | Enable TLS for the Trino connection. |
+| `--server-ssl-trust-all` | false | Disable TLS certificate verification (development only). |
+| `--explain-timeout <sec>` | `30` | Timeout in seconds for the remote `EXPLAIN (TYPE VALIDATE)` request. |
 
 ### Text output (basic — default)
 
@@ -291,12 +298,24 @@ analyze --validate-functions --udf-catalog udfs.yaml query.sql
 
 ### Lint rules
 
+**Phase 1 — local static analysis (always runs):**
+
 | Rule | Severity | Trigger |
 |---|---|---|
 | `W001` | WARNING | `SELECT *` detected; prefer an explicit column list. |
 | `W002` | WARNING | Function name not found in Trino built-in catalog (requires `--validate-functions`). |
 | `W003` | WARNING | Function call arity does not match the UDF definition (requires `--udf-catalog`). |
 | `E001` | ERROR | `DELETE` without a `WHERE` clause will affect all rows. |
+
+**Phase 2 — remote validation via `EXPLAIN (TYPE VALIDATE)` (requires `--server`, runs only when Phase 1 has no errors):**
+
+| Rule | Severity | Trigger |
+|---|---|---|
+| `W004` | WARNING | Other `USER_ERROR` from the Trino server not covered by E002–E005. |
+| `E002` | ERROR | Table or view not found (`TABLE_NOT_FOUND`). |
+| `E003` | ERROR | Column not found (`COLUMN_NOT_FOUND`). |
+| `E004` | ERROR | Function not found on the server (`FUNCTION_NOT_FOUND`). |
+| `E005` | ERROR | Type mismatch (`TYPE_MISMATCH`). |
 
 ---
 

--- a/docs/remote-validation-spec.md
+++ b/docs/remote-validation-spec.md
@@ -1,0 +1,438 @@
+# Remote Server Validation 仕様書
+
+## 概要
+
+`analyze` サブコマンドに、実際の Trino クラスターへ接続して SQL を検証する
+**2段階バリデーション** を追加する。
+
+```
+Phase 1 (ローカル静的解析) → Phase 2 (リモート EXPLAIN (TYPE VALIDATE) 検証)
+```
+
+- **Phase 1**: 構文パース・W001〜W003・E001 などの静的解析を実行する（既存機能）。
+- **Phase 2**: Phase 1 で ERROR レベルの finding が発生しなかった場合に限り、
+  Trino サーバーへ `EXPLAIN (TYPE VALIDATE) <query>` を送信してリモート検証を実行する。
+
+Phase 1 で ERROR が出た場合は Phase 2 をスキップし、即座に結果を返す。
+これにより、構文エラーなどのクエリで不要なネットワーク通信を行わない。
+
+---
+
+## 2段階バリデーション フロー
+
+```
+analyze --server localhost:8080 query.sql
+        │
+        ▼
+ ┌─────────────────────────────────┐
+ │  Phase 1: ローカル静的解析       │
+ │  ・SqlParser 構文チェック         │
+ │  ・W001 / W002 / W003 / E001     │
+ └─────────────┬───────────────────┘
+               │
+        ERROR あり?
+       ┌───────┴────────┐
+      YES               NO
+       │                │
+       ▼                ▼
+   結果出力      ┌──────────────────────────────────────┐
+   (Phase 2     │  Phase 2: リモート検証                 │
+    スキップ)    │  ・EXPLAIN (TYPE VALIDATE) <query> 送信│
+                │  ・Valid=true → findings なし          │
+                │  ・エラー → LintFinding 変換           │
+                └──────────────┬─────────────┘
+                               │
+                           結果出力
+                    (Phase 1 + Phase 2 の findings)
+```
+
+---
+
+## 技術的スコープ
+
+### Phase 2 で追加される検証
+
+| 検証内容 | Trino のエラーコード |
+|---|---|
+| テーブル / ビューの存在確認 | `TABLE_NOT_FOUND` |
+| カラム名の存在確認 | `COLUMN_NOT_FOUND` |
+| 関数名・シグネチャの検証 | `FUNCTION_NOT_FOUND` |
+| 型不一致の検出 | `TYPE_MISMATCH` |
+| その他 USER_ERROR | (汎用 W004 として報告) |
+
+### 実装しない検証
+
+- クエリの実際の実行 (DML / DDL の変更操作)
+- パフォーマンス測定 (`EXPLAIN ANALYZE`)
+- DDL 文の `EXPLAIN (TYPE VALIDATE)` (将来拡張)
+- バッチ / 複数ステートメントのリモート実行
+
+---
+
+## EXPLAIN (TYPE VALIDATE) について
+
+Trino 435 が提供する `EXPLAIN (TYPE VALIDATE)` は、クエリを**実行せず**に
+構文・意味論（テーブル・カラム・関数の存在、型整合性）を一括検証する専用モードである。
+
+参照: https://trino.io/docs/435/sql/explain.html
+
+### 構文
+
+```sql
+EXPLAIN (TYPE VALIDATE) <statement>
+```
+
+### 成功時の応答
+
+検証が通過した場合、`Valid` 列が `true` の 1 行が返される。
+
+```
+ Valid
+-------
+ true
+(1 row)
+```
+
+`StatementClient.isFailed()` が `false` のまま `isFinished()` が `true` になる。
+
+### 失敗時の応答
+
+検証エラーが発生した場合、Trino はクエリを失敗扱いにし、
+`QueryError` にエラー名・メッセージ・行列位置 (`errorLocation`) を返す。
+
+**構文エラー例:**
+```
+line 1:8: mismatched input 'FORM'. Expecting: ...
+```
+
+**意味論エラー例 (テーブル不存在):**
+```
+line 1:15: Table 'mycat.myschema.nations' does not exist
+```
+
+`QueryError.errorLocation` (`lineNumber`, `columnNumber`) が得られる場合は、
+LintFinding のメッセージに `(line N, col M)` として付記する。
+
+### plain `EXPLAIN` との違い
+
+| 項目 | `EXPLAIN` | `EXPLAIN (TYPE VALIDATE)` |
+|---|---|---|
+| 目的 | 実行計画の表示 | 構文・意味論の検証のみ |
+| 返却データ | 実行計画テキスト (大量) | `Valid = true` の 1 行 |
+| 検証範囲 | 計画生成できる範囲 | 検証に特化 (より厳密) |
+| ネットワーク負荷 | 計画テキスト分のデータ転送 | 最小限 |
+
+バリデーション用途では `EXPLAIN (TYPE VALIDATE)` を使用する。
+
+---
+
+## 依存ライブラリ
+
+`io.trino:trino-client` を追加する。バージョンはプロジェクトの
+`${trino.version}` に揃える（現在 `435`）。
+
+```xml
+<!-- pom.xml -->
+<dependency>
+    <groupId>io.trino</groupId>
+    <artifactId>trino-client</artifactId>
+    <version>${trino.version}</version>
+</dependency>
+```
+
+`trino-client` が依存する `okhttp3` はこのライブラリが推移的に持ち込む。
+追加の HTTP クライアントライブラリは不要。
+
+### 主要クラス (trino-client 435)
+
+| クラス | 用途 |
+|---|---|
+| `ClientSession` | サーバー URI・ユーザー・カタログ・スキーマなどのセッション設定 |
+| `StatementClientFactory` | `StatementClient` のファクトリ (`newStatementClient()`) |
+| `StatementClient` | 非同期クエリ実行。`advance()` でポーリング |
+| `QueryError` | エラー情報 (`errorName`, `message`, `errorLocation`) |
+| `OkHttpUtil` | 認証 / SSL の `OkHttpClient` 設定ユーティリティ |
+
+---
+
+## 新しい CLI オプション
+
+`analyze` サブコマンドに以下のオプションを追加する。
+`--server` を指定しない場合はリモート検証は行われず、既存の動作に変化はない。
+
+```
+--server <host:port>           接続先 Trino サーバー (例: localhost:8080)
+--server-user <name>           Trino ユーザー名 (デフォルト: システムユーザー)
+--server-password <password>   パスワード (平文指定)
+--server-access-token <token>  Bearer トークン認証
+--server-ssl                   SSL/TLS を有効化
+--server-ssl-trust-all         SSL 証明書検証を無効化 (開発環境用)
+--explain-timeout <sec>        EXPLAIN のタイムアウト秒数 (デフォルト: 30)
+```
+
+> **注意**: `--server-password` は平文オプションとして提供するが、
+> セキュリティを重視する場合は環境変数 `TRINO_PASSWORD` の使用を推奨する。
+
+### 環境変数 (CI/CD 用)
+
+| 環境変数 | 対応オプション |
+|---|---|
+| `TRINO_SERVER` | `--server` |
+| `TRINO_USER` | `--server-user` |
+| `TRINO_PASSWORD` | `--server-password` |
+| `TRINO_ACCESS_TOKEN` | `--server-access-token` |
+
+環境変数はオプション指定で上書きされる。
+
+---
+
+## 実装クラス構成
+
+### 新規クラス
+
+| クラス | パッケージ | 役割 |
+|---|---|---|
+| `TrinoConnectionOptions` | `subcommand` | Picocli `@ArgGroup` で接続オプションをまとめた Mixin |
+| `TrinoRemoteValidator` | `core` | 2段階フロー制御。Phase 1 結果を受け取り Phase 2 を実行 |
+| `TrinoExplainClient` | `core` | `trino-client` ラッパー。`explain(sql)` メソッドを提供 |
+| `RemoteValidationResult` | `core` | EXPLAIN 結果 (成功/失敗) と生成された `LintFinding` リスト |
+
+### 変更クラス
+
+| クラス | 変更内容 |
+|---|---|
+| `Analyze.java` | `TrinoConnectionOptions` を `@ArgGroup` で組み込み、`TrinoRemoteValidator` を呼び出す |
+| `QueryAnalysisResult.java` | Phase 2 由来の findings (E002〜E005, W004) を格納する `remotefindings` フィールド追加 |
+
+---
+
+## 実装詳細
+
+### TrinoExplainClient
+
+```java
+public final class TrinoExplainClient implements Closeable {
+
+    private final OkHttpClient httpClient;
+    private final ClientSession session;
+
+    /**
+     * Creates an OkHttpClient with the given authentication and SSL settings.
+     * Uses OkHttpUtil.basicAuth() / OkHttpUtil.tokenAuth() / OkHttpUtil.setupInsecureSsl().
+     */
+    public static TrinoExplainClient create(TrinoConnectionOptions opts) { ... }
+
+    /**
+     * Executes "EXPLAIN (TYPE VALIDATE) <sql>" on the remote server.
+     * Polls StatementClient.advance() until isFinished() or isFailed().
+     * On success (Valid = true), returns an empty findings list.
+     * On failure, converts QueryError to LintFinding list.
+     */
+    public RemoteValidationResult validate(String sql) { ... }
+}
+```
+
+### ClientSession の構築
+
+```java
+ClientSession session = ClientSession.builder()
+    .server(URI.create("http://" + opts.getServer()))   // https の場合はそのまま
+    .user(Optional.ofNullable(opts.getUser()))
+    .catalog(Optional.ofNullable(catalog))              // Analyze の --catalog を転用
+    .schema(Optional.ofNullable(schema))                // Analyze の --schema を転用
+    .timeZone(ZoneId.systemDefault())
+    .locale(Locale.getDefault())
+    .clientRequestTimeout(Duration.ofSeconds(opts.getExplainTimeout()))
+    .build();
+```
+
+### OkHttpClient の構築
+
+```java
+OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+if (opts.getAccessToken() != null) {
+    OkHttpUtil.tokenAuth(opts.getAccessToken()).apply(builder);
+} else if (opts.getUser() != null && opts.getPassword() != null) {
+    OkHttpUtil.basicAuth(opts.getUser(), opts.getPassword()).apply(builder);
+}
+
+if (opts.isSslTrustAll()) {
+    OkHttpUtil.setupInsecureSsl(builder);
+} else if (opts.isSsl()) {
+    OkHttpUtil.setupSsl(builder, ...);
+}
+
+OkHttpClient httpClient = builder.build();
+```
+
+### EXPLAIN (TYPE VALIDATE) 実行とポーリング
+
+```java
+// EXPLAIN (TYPE VALIDATE) を使用。クエリを実行せず検証のみ実施。
+String validateSql = "EXPLAIN (TYPE VALIDATE) " + originalSql;
+StatementClient client =
+    StatementClientFactory.newStatementClient(httpClient, session, validateSql);
+
+while (client.isRunning()) {
+    client.advance();
+}
+
+if (client.isFinished()) {
+    // 成功: Valid = true の 1 行が返る。findings は空。
+    return RemoteValidationResult.valid();
+}
+
+if (client.isFailed()) {
+    QueryError err = client.finalStatusInfo().getError();
+    // err.getErrorName()  → LintFinding のルール ID を決定
+    // err.getMessage()    → メッセージ本文
+    // err.getErrorLocation() → 行・列番号 (null の場合あり)
+    return RemoteValidationResult.failed(toFindings(err));
+}
+```
+
+`errorLocation` が非 null の場合、LintFinding のメッセージに
+`(line N, col M)` を付記してエラー箇所を示す。
+
+---
+
+## エラー → LintFinding 変換規則
+
+Trino の `QueryError.errorName` をもとに LintFinding を生成する。
+
+| `errorName` (Trino) | 生成する LintFinding | 重大度 |
+|---|---|---|
+| `TABLE_NOT_FOUND` | E002: `Table not found: {message}` | ERROR |
+| `COLUMN_NOT_FOUND` | E003: `Column not found: {message}` | ERROR |
+| `FUNCTION_NOT_FOUND` | E004: `Function not found: {message}` | ERROR |
+| `TYPE_MISMATCH` | E005: `Type mismatch: {message}` | ERROR |
+| その他 `USER_ERROR` | W004: `Server validation warning: {message}` | WARNING |
+| `INTERNAL_ERROR` / 接続失敗 | (stderr に警告を出力して Phase 2 の結果は省略) | — |
+
+`INTERNAL_ERROR` などサーバー起因のエラーはクエリの問題ではないため、
+findings には追加せず stderr に警告のみ出力して終了コード 0 を維持する。
+
+---
+
+## 新しい lint ルール (全ルール更新版)
+
+| ルール ID | 重大度 | メッセージ例 | トリガー条件 |
+|---|---|---|---|
+| W001 | WARNING | `SELECT * detected; prefer an explicit column list` | SELECT * を検出 |
+| W002 | WARNING | `Unknown function: {name}; may be a custom UDF or typo` | `--validate-functions` 時、未知の関数名 |
+| W003 | WARNING | `Function {name} expects {n} argument(s), got {m}` | `--udf-catalog` 時、アリティ不一致 |
+| W004 | WARNING | `Server validation warning: {message}` | Phase 2 で USER_ERROR (非 ERROR 系) |
+| E001 | ERROR | `DELETE without WHERE clause will affect all rows` | WHERE なしの DELETE |
+| E002 | ERROR | `Table not found: {message}` | Phase 2: TABLE_NOT_FOUND |
+| E003 | ERROR | `Column not found: {message}` | Phase 2: COLUMN_NOT_FOUND |
+| E004 | ERROR | `Function not found: {message}` | Phase 2: FUNCTION_NOT_FOUND |
+| E005 | ERROR | `Type mismatch: {message}` | Phase 2: TYPE_MISMATCH |
+
+---
+
+## 出力例
+
+### テーブルが存在しない場合 (text 形式)
+
+```
+=========================
+Catalogs: [mycat]
+QueryType: Query
+Tables: [mycat.myschema.unknown_table]
+Functions: scalar=[], aggregate=[count], window=[]
+Lint: [ERROR] E002: Table not found: Table mycat.myschema.unknown_table does not exist
+```
+
+### W002 (ローカル) + E002 (リモート) の組み合わせ (json 形式)
+
+Phase 1 は WARNING のみ（ERROR なし）のためリモート検証に進む例:
+
+```json
+{
+  "queryType": "Query",
+  "catalogs": ["mycat"],
+  "tables": ["mycat.s.t"],
+  "unknownFunctions": ["my_udf"],
+  "findings": [
+    {"ruleId": "W002", "severity": "WARNING",
+     "message": "Unknown function: my_udf; may be a custom UDF or typo"},
+    {"ruleId": "E002", "severity": "ERROR",
+     "message": "Table not found: Table mycat.s.t does not exist"}
+  ]
+}
+```
+
+### Phase 1 で ERROR → Phase 2 スキップの例
+
+```bash
+# DELETE without WHERE → E001 が出るためリモート検証はスキップ
+$ analyze --server localhost:8080 query.sql   # query: DELETE FROM t
+
+=========================
+QueryType: Delete
+Tables: [t]
+Lint: [ERROR] E001: DELETE without WHERE clause will affect all rows
+# Phase 2 はスキップ (リモートサーバーへの接続なし)
+```
+
+---
+
+## 利用例
+
+```bash
+# 基本 (認証なし・ローカル開発環境)
+analyze --server localhost:8080 query.sql
+
+# カタログ・スキーマを指定
+analyze --server localhost:8080 --catalog hive --schema default query.sql
+
+# Basic 認証
+analyze --server trino.example.com:443 \
+        --server-ssl \
+        --server-user alice \
+        --server-password s3cr3t \
+        query.sql
+
+# Bearer トークン認証
+analyze --server trino.example.com:443 \
+        --server-ssl \
+        --server-access-token "$TOKEN" \
+        query.sql
+
+# 静的解析 (W002/W003) + リモート検証を組み合わせ
+analyze --validate-functions \
+        --udf-catalog udfs.yaml \
+        --server localhost:8080 \
+        query.sql
+
+# 環境変数を使った CI/CD 利用
+TRINO_SERVER=trino.prod:443 \
+TRINO_ACCESS_TOKEN="$CI_TOKEN" \
+  analyze --server-ssl query.sql
+```
+
+---
+
+## 後方互換性
+
+- `--server` を指定しない場合、Phase 2 は実行されず既存の動作に変化なし。
+- `--server` を指定した場合も、Phase 1 の静的解析 (W001〜W003、E001) は常に実行される。
+- Phase 2 でネットワーク接続失敗・タイムアウトが発生した場合は stderr に警告を出力し、
+  Phase 1 の結果のみを返す (終了コードは Phase 1 の結果に基づく)。
+- 既存の `QueryAnalyzer.analyze()` シグネチャは変更しない。
+  `TrinoRemoteValidator` が `QueryAnalysisResult` を受け取り Phase 2 を追記する形とする。
+
+---
+
+## 実装順序
+
+1. `pom.xml` に `trino-client` 依存を追加
+2. `TrinoConnectionOptions.java` (Picocli ArgGroup) を作成
+3. `TrinoExplainClient.java` を作成 (OkHttpUtil + StatementClientFactory ラッパー)
+4. `RemoteValidationResult.java` を作成
+5. `TrinoRemoteValidator.java` を作成 (2段階フロー制御)
+6. `QueryAnalysisResult.java` に `remoteFindings` フィールドを追加
+7. `Analyze.java` に `TrinoConnectionOptions` を組み込み
+8. テスト作成 (WireMock または Trino embedded でスタブ)
+9. `./mvnw verify` で全スイート確認

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <version>${trino.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <version>${trino.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
@@ -75,6 +75,12 @@ public final class QueryAnalysisResult {
      */
     private final List<LintFinding> w003Findings = new ArrayList<>();
 
+    /**
+     * Findings produced by Phase 2 remote validation (E002–E005, W004).
+     * Empty when remote validation was not performed or the query passed.
+     */
+    private final List<LintFinding> remoteFindings = new ArrayList<>();
+
     private QueryAnalysisResult(Builder b) {
         this.queryType = b.queryType;
         this.catalogs = Collections.unmodifiableSet(new LinkedHashSet<>(b.catalogs));
@@ -91,6 +97,7 @@ public final class QueryAnalysisResult {
         this.writeTargets.addAll(b.writeTargets);
         this.unknownFunctions.addAll(b.unknownFunctions);
         this.w003Findings.addAll(b.w003Findings);
+        this.remoteFindings.addAll(b.remoteFindings);
     }
 
     /**
@@ -223,7 +230,41 @@ public final class QueryAnalysisResult {
             findings.add(new LintFinding("E001", LintFinding.Severity.ERROR,
                 "DELETE without WHERE clause will affect all rows"));
         }
+        findings.addAll(this.remoteFindings);
         return Collections.unmodifiableList(findings);
+    }
+
+    /**
+     * Returns a new {@link QueryAnalysisResult} with the given remote findings appended.
+     *
+     * <p>All Phase 1 data is copied unchanged; the remote findings list is replaced with the
+     * supplied list. Used by {@link TrinoRemoteValidator} to attach Phase 2 results.
+     *
+     * @param newRemoteFindings findings produced by remote {@code EXPLAIN (TYPE VALIDATE)}
+     * @return new result instance with remote findings populated
+     */
+    public QueryAnalysisResult withRemoteFindings(List<LintFinding> newRemoteFindings) {
+        Builder b = new Builder();
+        b.queryType = this.queryType;
+        b.catalogs.addAll(this.catalogs);
+        b.tables.addAll(this.tables);
+        b.usesSelectStar = this.usesSelectStar;
+        b.hasLimit = this.hasLimit;
+        b.hasWhereOnDelete = this.hasWhereOnDelete;
+        b.parseError = this.parseError;
+        b.ctes.addAll(this.ctes);
+        b.joins.addAll(this.joins);
+        b.functionsScalar.addAll(this.functionsScalar);
+        b.functionsAggregate.addAll(this.functionsAggregate);
+        b.functionsWindow.addAll(this.functionsWindow);
+        b.writeTargets.addAll(this.writeTargets);
+        b.unknownFunctions.addAll(this.unknownFunctions);
+        b.w003Findings.addAll(this.w003Findings);
+        b.remoteFindings.addAll(this.remoteFindings);
+        if (newRemoteFindings != null) {
+            b.remoteFindings.addAll(newRemoteFindings);
+        }
+        return new QueryAnalysisResult(b);
     }
 
     /**
@@ -367,6 +408,11 @@ public final class QueryAnalysisResult {
          * W003 arity mismatch findings generated when a UDF catalog is provided.
          */
         private final List<LintFinding> w003Findings = new ArrayList<>();
+
+        /**
+         * E002-E005 / W004 findings from Phase 2 remote EXPLAIN (TYPE VALIDATE).
+         */
+        private final List<LintFinding> remoteFindings = new ArrayList<>();
 
         /**
          * @param v query type value

--- a/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
+++ b/src/main/java/io/github/yuokada/core/QueryAnalysisResult.java
@@ -260,7 +260,7 @@ public final class QueryAnalysisResult {
         b.writeTargets.addAll(this.writeTargets);
         b.unknownFunctions.addAll(this.unknownFunctions);
         b.w003Findings.addAll(this.w003Findings);
-        b.remoteFindings.addAll(this.remoteFindings);
+        // Do NOT copy this.remoteFindings; withRemoteFindings() replaces them with newRemoteFindings.
         if (newRemoteFindings != null) {
             b.remoteFindings.addAll(newRemoteFindings);
         }

--- a/src/main/java/io/github/yuokada/core/RemoteValidationResult.java
+++ b/src/main/java/io/github/yuokada/core/RemoteValidationResult.java
@@ -1,0 +1,77 @@
+package io.github.yuokada.core;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of executing {@code EXPLAIN (TYPE VALIDATE)} against a remote Trino server.
+ *
+ * <p>A result is either:
+ * <ul>
+ *   <li><strong>valid</strong> — the server accepted the query; {@link #getFindings()} is empty.</li>
+ *   <li><strong>failed</strong> — the server returned an error; {@link #getFindings()} contains
+ *       one or more {@link LintFinding} entries (E002–E005, W004).</li>
+ *   <li><strong>skipped</strong> — remote validation was not attempted (e.g. Phase 1 had errors
+ *       or the server was unreachable); {@link #isSkipped()} returns {@code true}.</li>
+ * </ul>
+ */
+public final class RemoteValidationResult {
+
+    private final boolean skipped;
+    private final List<LintFinding> findings;
+
+    private RemoteValidationResult(boolean skipped, List<LintFinding> findings) {
+        this.skipped = skipped;
+        this.findings = Collections.unmodifiableList(findings);
+    }
+
+    /**
+     * Creates a result representing a successful validation ({@code Valid = true}).
+     *
+     * @return result with no findings
+     */
+    public static RemoteValidationResult valid() {
+        return new RemoteValidationResult(false, Collections.emptyList());
+    }
+
+    /**
+     * Creates a result representing a validation failure with one or more lint findings.
+     *
+     * @param findings non-null list of findings derived from the Trino error response
+     * @return result with findings
+     */
+    public static RemoteValidationResult failed(List<LintFinding> findings) {
+        return new RemoteValidationResult(false, findings);
+    }
+
+    /**
+     * Creates a result indicating that remote validation was skipped.
+     *
+     * <p>This is used when Phase 1 produced ERROR-level findings (no need to contact the server)
+     * or when the server was unreachable / returned an internal error.
+     *
+     * @return skipped result with no findings
+     */
+    public static RemoteValidationResult skipped() {
+        return new RemoteValidationResult(true, Collections.emptyList());
+    }
+
+    /**
+     * Returns {@code true} when remote validation was not performed.
+     *
+     * @return {@code true} if skipped
+     */
+    public boolean isSkipped() {
+        return this.skipped;
+    }
+
+    /**
+     * Returns the lint findings produced by the remote validation.
+     * Empty when validation passed or was skipped.
+     *
+     * @return unmodifiable list of findings (may be empty, never null)
+     */
+    public List<LintFinding> getFindings() {
+        return this.findings;
+    }
+}

--- a/src/main/java/io/github/yuokada/core/TrinoExplainClient.java
+++ b/src/main/java/io/github/yuokada/core/TrinoExplainClient.java
@@ -49,6 +49,7 @@ public final class TrinoExplainClient implements Closeable {
      * @param catalog default catalog for the session (may be {@code null})
      * @param schema  default schema for the session (may be {@code null})
      * @return a configured client ready to execute validate requests
+     * @throws IllegalArgumentException if the server address produces an invalid URI
      */
     public static TrinoExplainClient create(
             TrinoConnectionOptions opts, String catalog, String schema) {
@@ -57,15 +58,31 @@ public final class TrinoExplainClient implements Closeable {
         // Authentication
         String token = opts.getAccessToken();
         String password = opts.getPassword();
+        boolean hasAuth = false;
         if (token != null && !token.isBlank()) {
             builder.addInterceptor(OkHttpUtil.tokenAuth(token));
+            hasAuth = true;
         } else if (password != null && !password.isBlank()) {
             builder.addInterceptor(OkHttpUtil.basicAuth(opts.getUser(), password));
+            hasAuth = true;
         }
 
         // SSL
         if (opts.isSslTrustAll()) {
+            if (opts.isSsl()) {
+                // Both --server-ssl and --server-ssl-trust-all supplied:
+                // trust-all takes precedence and disables certificate verification.
+                System.err.println("[remote-validation] WARNING: --server-ssl-trust-all disables "
+                    + "certificate verification; --server-ssl is redundant when trust-all is set.");
+            }
             OkHttpUtil.setupInsecureSsl(builder);
+        }
+
+        // Warn when credentials are sent over plain HTTP (no TLS).
+        // --server-ssl or --server-ssl-trust-all must be set to protect credentials.
+        if (hasAuth && !opts.isSsl() && !opts.isSslTrustAll()) {
+            System.err.println("[remote-validation] WARNING: authentication credentials are being "
+                + "sent over plain HTTP. Use --server-ssl to enable TLS.");
         }
 
         // Timeout
@@ -76,14 +93,20 @@ public final class TrinoExplainClient implements Closeable {
 
         OkHttpClient httpClient = builder.build();
 
-        // Build the server URI
+        // Build the server URI. The scheme is determined by --server-ssl / --server-ssl-trust-all.
         String server = opts.getServer();
-        String scheme = opts.isSsl() ? "https" : "http";
-        URI serverUri = URI.create(scheme + "://" + server);
+        String scheme = (opts.isSsl() || opts.isSslTrustAll()) ? "https" : "http";
+        URI serverUri;
+        try {
+            serverUri = URI.create(scheme + "://" + server);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                "Invalid Trino server URI: " + scheme + "://" + server, e);
+        }
 
         ClientSession clientSession = ClientSession.builder()
             .server(serverUri)
-            .user(Optional.of(opts.getUser()))
+            .user(Optional.ofNullable(opts.getUser()))
             .catalog(catalog)
             .schema(schema)
             .timeZone(ZoneId.systemDefault())
@@ -102,10 +125,18 @@ public final class TrinoExplainClient implements Closeable {
      * On internal server error or unexpected state, returns {@link RemoteValidationResult#skipped()}
      * and emits a warning to stderr.
      *
-     * @param sql the original SQL statement (without the {@code EXPLAIN} prefix)
+     * <p>The {@code sql} parameter must be the original statement without any {@code EXPLAIN}
+     * prefix. Passing a statement that already starts with {@code EXPLAIN} would produce a
+     * malformed query.
+     *
+     * @param sql the original SQL statement (must not be {@code null} or start with EXPLAIN)
      * @return validation result
+     * @throws IllegalArgumentException if {@code sql} is {@code null}
      */
     public RemoteValidationResult validate(String sql) {
+        if (sql == null) {
+            throw new IllegalArgumentException("sql must not be null");
+        }
         String validateSql = "EXPLAIN (TYPE VALIDATE) " + sql;
 
         try (StatementClient client =
@@ -135,7 +166,8 @@ public final class TrinoExplainClient implements Closeable {
             }
 
             // Unexpected state
-            System.err.println("[remote-validation] Unexpected client state after EXPLAIN (TYPE VALIDATE)");
+            System.err.println(
+                "[remote-validation] Unexpected client state after EXPLAIN (TYPE VALIDATE)");
             return RemoteValidationResult.skipped();
 
         } catch (Exception e) {
@@ -188,7 +220,7 @@ public final class TrinoExplainClient implements Closeable {
                 break;
         }
 
-        String message = buildMessage(ruleId, err);
+        String message = buildMessage(err);
         findings.add(new LintFinding(ruleId, severity, message));
         return findings;
     }
@@ -197,12 +229,21 @@ public final class TrinoExplainClient implements Closeable {
      * Builds a human-readable message string from a {@link QueryError},
      * optionally appending location information when {@link ErrorLocation} is available.
      *
-     * @param ruleId rule identifier for the message prefix
-     * @param err    query error from the server
-     * @return formatted message string
+     * <p>Falls back to the error name, then to {@code "Unknown server error"} when
+     * both {@code message} and {@code errorName} are {@code null}.
+     *
+     * @param err query error from the server
+     * @return formatted message string (never {@code null})
      */
-    private static String buildMessage(String ruleId, QueryError err) {
-        String base = err.getMessage() != null ? err.getMessage() : err.getErrorName();
+    private static String buildMessage(QueryError err) {
+        String base;
+        if (err.getMessage() != null) {
+            base = err.getMessage();
+        } else if (err.getErrorName() != null) {
+            base = err.getErrorName();
+        } else {
+            base = "Unknown server error";
+        }
         ErrorLocation loc = err.getErrorLocation();
         if (loc != null) {
             return base + " (line " + loc.getLineNumber() + ", col " + loc.getColumnNumber() + ")";

--- a/src/main/java/io/github/yuokada/core/TrinoExplainClient.java
+++ b/src/main/java/io/github/yuokada/core/TrinoExplainClient.java
@@ -1,0 +1,221 @@
+package io.github.yuokada.core;
+
+import io.github.yuokada.subcommand.TrinoConnectionOptions;
+import io.trino.client.ClientSession;
+import io.trino.client.ErrorLocation;
+import io.trino.client.OkHttpUtil;
+import io.trino.client.QueryError;
+import io.trino.client.StatementClient;
+import io.trino.client.StatementClientFactory;
+import java.io.Closeable;
+import java.net.URI;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+
+/**
+ * Wraps {@code io.trino:trino-client} to execute
+ * {@code EXPLAIN (TYPE VALIDATE)} against a remote Trino server.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * try (TrinoExplainClient client = TrinoExplainClient.create(opts, catalog, schema)) {
+ *     RemoteValidationResult result = client.validate(sql);
+ * }
+ * }</pre>
+ */
+public final class TrinoExplainClient implements Closeable {
+
+    private final OkHttpClient httpClient;
+    private final ClientSession session;
+
+    private TrinoExplainClient(OkHttpClient httpClient, ClientSession session) {
+        this.httpClient = httpClient;
+        this.session = session;
+    }
+
+    /**
+     * Creates a {@code TrinoExplainClient} configured from the given connection options.
+     *
+     * <p>The {@code catalog} and {@code schema} parameters are forwarded as the session's
+     * default catalog/schema so that unqualified table references resolve correctly during
+     * {@code EXPLAIN (TYPE VALIDATE)}.
+     *
+     * @param opts    connection options (server, user, auth, SSL)
+     * @param catalog default catalog for the session (may be {@code null})
+     * @param schema  default schema for the session (may be {@code null})
+     * @return a configured client ready to execute validate requests
+     */
+    public static TrinoExplainClient create(
+            TrinoConnectionOptions opts, String catalog, String schema) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+        // Authentication
+        String token = opts.getAccessToken();
+        String password = opts.getPassword();
+        if (token != null && !token.isBlank()) {
+            builder.addInterceptor(OkHttpUtil.tokenAuth(token));
+        } else if (password != null && !password.isBlank()) {
+            builder.addInterceptor(OkHttpUtil.basicAuth(opts.getUser(), password));
+        }
+
+        // SSL
+        if (opts.isSslTrustAll()) {
+            OkHttpUtil.setupInsecureSsl(builder);
+        }
+
+        // Timeout
+        long timeoutSec = opts.getExplainTimeout();
+        builder.connectTimeout(timeoutSec, TimeUnit.SECONDS);
+        builder.readTimeout(timeoutSec, TimeUnit.SECONDS);
+        builder.writeTimeout(timeoutSec, TimeUnit.SECONDS);
+
+        OkHttpClient httpClient = builder.build();
+
+        // Build the server URI
+        String server = opts.getServer();
+        String scheme = opts.isSsl() ? "https" : "http";
+        URI serverUri = URI.create(scheme + "://" + server);
+
+        ClientSession clientSession = ClientSession.builder()
+            .server(serverUri)
+            .user(Optional.of(opts.getUser()))
+            .catalog(catalog)
+            .schema(schema)
+            .timeZone(ZoneId.systemDefault())
+            .locale(Locale.getDefault())
+            .build();
+
+        return new TrinoExplainClient(httpClient, clientSession);
+    }
+
+    /**
+     * Executes {@code EXPLAIN (TYPE VALIDATE) <sql>} on the remote Trino server.
+     *
+     * <p>On success ({@code Valid = true}), returns {@link RemoteValidationResult#valid()}.
+     * On failure, converts {@link QueryError} fields into {@link LintFinding} entries and
+     * returns {@link RemoteValidationResult#failed(List)}.
+     * On internal server error or unexpected state, returns {@link RemoteValidationResult#skipped()}
+     * and emits a warning to stderr.
+     *
+     * @param sql the original SQL statement (without the {@code EXPLAIN} prefix)
+     * @return validation result
+     */
+    public RemoteValidationResult validate(String sql) {
+        String validateSql = "EXPLAIN (TYPE VALIDATE) " + sql;
+
+        try (StatementClient client =
+                StatementClientFactory.newStatementClient(this.httpClient, this.session, validateSql)) {
+            while (client.isRunning()) {
+                client.advance();
+            }
+
+            if (client.isClientAborted() || client.isClientError()) {
+                System.err.println("[remote-validation] Client error during EXPLAIN (TYPE VALIDATE)");
+                return RemoteValidationResult.skipped();
+            }
+
+            if (client.isFinished()) {
+                QueryError err = client.finalStatusInfo().getError();
+                if (err == null) {
+                    // Valid = true — server accepted the query
+                    return RemoteValidationResult.valid();
+                }
+                String errorType = err.getErrorType();
+                if ("INTERNAL_ERROR".equals(errorType)) {
+                    System.err.println(
+                        "[remote-validation] Server internal error: " + err.getMessage());
+                    return RemoteValidationResult.skipped();
+                }
+                return RemoteValidationResult.failed(toFindings(err));
+            }
+
+            // Unexpected state
+            System.err.println("[remote-validation] Unexpected client state after EXPLAIN (TYPE VALIDATE)");
+            return RemoteValidationResult.skipped();
+
+        } catch (Exception e) {
+            System.err.println("[remote-validation] Connection error: " + e.getMessage());
+            return RemoteValidationResult.skipped();
+        }
+    }
+
+    /**
+     * Converts a {@link QueryError} from Trino into a list of {@link LintFinding} entries.
+     *
+     * <p>The error name is mapped to a rule ID as follows:
+     * <ul>
+     *   <li>{@code TABLE_NOT_FOUND} → E002</li>
+     *   <li>{@code COLUMN_NOT_FOUND} → E003</li>
+     *   <li>{@code FUNCTION_NOT_FOUND} → E004</li>
+     *   <li>{@code TYPE_MISMATCH} → E005</li>
+     *   <li>Other {@code USER_ERROR} → W004</li>
+     * </ul>
+     *
+     * @param err the query error from the server
+     * @return list containing a single lint finding
+     */
+    private static List<LintFinding> toFindings(QueryError err) {
+        List<LintFinding> findings = new ArrayList<>();
+        String ruleId;
+        LintFinding.Severity severity;
+
+        String errorName = err.getErrorName() != null ? err.getErrorName() : "";
+        switch (errorName) {
+            case "TABLE_NOT_FOUND":
+                ruleId = "E002";
+                severity = LintFinding.Severity.ERROR;
+                break;
+            case "COLUMN_NOT_FOUND":
+                ruleId = "E003";
+                severity = LintFinding.Severity.ERROR;
+                break;
+            case "FUNCTION_NOT_FOUND":
+                ruleId = "E004";
+                severity = LintFinding.Severity.ERROR;
+                break;
+            case "TYPE_MISMATCH":
+                ruleId = "E005";
+                severity = LintFinding.Severity.ERROR;
+                break;
+            default:
+                ruleId = "W004";
+                severity = LintFinding.Severity.WARNING;
+                break;
+        }
+
+        String message = buildMessage(ruleId, err);
+        findings.add(new LintFinding(ruleId, severity, message));
+        return findings;
+    }
+
+    /**
+     * Builds a human-readable message string from a {@link QueryError},
+     * optionally appending location information when {@link ErrorLocation} is available.
+     *
+     * @param ruleId rule identifier for the message prefix
+     * @param err    query error from the server
+     * @return formatted message string
+     */
+    private static String buildMessage(String ruleId, QueryError err) {
+        String base = err.getMessage() != null ? err.getMessage() : err.getErrorName();
+        ErrorLocation loc = err.getErrorLocation();
+        if (loc != null) {
+            return base + " (line " + loc.getLineNumber() + ", col " + loc.getColumnNumber() + ")";
+        }
+        return base;
+    }
+
+    /**
+     * Closes the underlying {@link OkHttpClient} and releases its resources.
+     */
+    @Override
+    public void close() {
+        this.httpClient.dispatcher().executorService().shutdown();
+        this.httpClient.connectionPool().evictAll();
+    }
+}

--- a/src/main/java/io/github/yuokada/core/TrinoRemoteValidator.java
+++ b/src/main/java/io/github/yuokada/core/TrinoRemoteValidator.java
@@ -1,0 +1,77 @@
+package io.github.yuokada.core;
+
+import io.github.yuokada.subcommand.TrinoConnectionOptions;
+import java.util.List;
+
+/**
+ * Implements the two-phase validation strategy:
+ *
+ * <ol>
+ *   <li><strong>Phase 1</strong> (local static analysis) — performed by {@link QueryAnalyzer}
+ *       and {@link QueryAnalysisResult} before this class is involved.</li>
+ *   <li><strong>Phase 2</strong> (remote {@code EXPLAIN (TYPE VALIDATE)}) — executed only when
+ *       Phase 1 produced no ERROR-level {@link LintFinding} entries.</li>
+ * </ol>
+ *
+ * <p>This class is a pure utility class and cannot be instantiated.
+ */
+public final class TrinoRemoteValidator {
+
+    private TrinoRemoteValidator() {
+    }
+
+    /**
+     * Runs Phase 2 remote validation if appropriate, and returns the combined result.
+     *
+     * <p>Phase 2 is skipped when:
+     * <ul>
+     *   <li>Remote validation is not configured ({@link TrinoConnectionOptions#isEnabled()} is
+     *       {@code false}).</li>
+     *   <li>Phase 1 produced at least one ERROR-level finding.</li>
+     * </ul>
+     *
+     * <p>When Phase 2 runs, the returned {@link QueryAnalysisResult} has its remote findings
+     * list populated. The original Phase 1 result is returned unchanged when Phase 2 is skipped.
+     *
+     * @param phase1    the result of local static analysis (Phase 1)
+     * @param sql       the original SQL statement
+     * @param opts      Trino connection options (may have {@code isEnabled() == false})
+     * @param catalog   default catalog for the remote session (may be {@code null})
+     * @param schema    default schema for the remote session (may be {@code null})
+     * @return a {@link QueryAnalysisResult} augmented with Phase 2 findings, or the original
+     *         Phase 1 result when Phase 2 was skipped
+     */
+    public static QueryAnalysisResult validate(
+            QueryAnalysisResult phase1,
+            String sql,
+            TrinoConnectionOptions opts,
+            String catalog,
+            String schema) {
+
+        if (!opts.isEnabled()) {
+            return phase1;
+        }
+
+        // Skip Phase 2 when Phase 1 has any ERROR-level finding
+        List<LintFinding> phase1Findings = phase1.getFindings();
+        boolean phase1HasError = phase1Findings.stream()
+            .anyMatch(f -> f.getSeverity() == LintFinding.Severity.ERROR);
+        if (phase1HasError) {
+            return phase1;
+        }
+
+        RemoteValidationResult remote;
+        try (TrinoExplainClient client = TrinoExplainClient.create(opts, catalog, schema)) {
+            remote = client.validate(sql);
+        } catch (Exception e) {
+            System.err.println("[remote-validation] Unexpected error: " + e.getMessage());
+            remote = RemoteValidationResult.skipped();
+        }
+
+        if (remote.isSkipped() || remote.getFindings().isEmpty()) {
+            return phase1;
+        }
+
+        return phase1.withRemoteFindings(remote.getFindings());
+    }
+}

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -5,6 +5,7 @@ import io.github.yuokada.core.AstView;
 import io.github.yuokada.core.ExitCodes;
 import io.github.yuokada.core.QueryAnalysisResult;
 import io.github.yuokada.core.QueryAnalyzer;
+import io.github.yuokada.core.TrinoRemoteValidator;
 import io.github.yuokada.core.UdfCatalog;
 import io.github.yuokada.core.UdfDefinition;
 import io.github.yuokada.subcommand.output.AnalysisPrinter;
@@ -141,6 +142,13 @@ public class Analyze implements Callable<Integer> {
         description = "YAML file with UDF definitions for arity validation (W003).")
     private String udfCatalogPath;
 
+    /**
+     * Trino server connection options for Phase 2 remote EXPLAIN (TYPE VALIDATE).
+     * Remote validation is only performed when {@code --server} is specified.
+     */
+    @CommandLine.ArgGroup(heading = "%nRemote Validation Options:%n", validate = false)
+    private TrinoConnectionOptions serverOptions = new TrinoConnectionOptions();
+
     @Override
     public Integer call() throws IOException {
         AstView view;
@@ -184,6 +192,9 @@ public class Analyze implements Callable<Integer> {
             QueryAnalysisResult result =
                 QueryAnalyzer.analyze(statement, defaultCatalog, defaultSchema,
                     effectiveKnown, udfCatalog);
+            // Phase 2: remote validation via EXPLAIN (TYPE VALIDATE)
+            result = TrinoRemoteValidator.validate(
+                result, statement, this.serverOptions, this.defaultCatalog, this.defaultSchema);
             printer.printStatement(result, null, statement);
         }
         return ExitCode.OK;
@@ -331,5 +342,9 @@ public class Analyze implements Callable<Integer> {
 
     void setUdfCatalogPath(String udfCatalogPath) {
         this.udfCatalogPath = udfCatalogPath;
+    }
+
+    void setServerOptions(TrinoConnectionOptions serverOptions) {
+        this.serverOptions = serverOptions;
     }
 }

--- a/src/main/java/io/github/yuokada/subcommand/TrinoConnectionOptions.java
+++ b/src/main/java/io/github/yuokada/subcommand/TrinoConnectionOptions.java
@@ -1,0 +1,195 @@
+package io.github.yuokada.subcommand;
+
+import picocli.CommandLine;
+
+/**
+ * Picocli {@link CommandLine.ArgGroup} that bundles all Trino server connection options.
+ *
+ * <p>These options are only effective when {@code --server} is specified. When absent,
+ * the remote validation phase (Phase 2) is skipped entirely.
+ */
+public class TrinoConnectionOptions {
+
+    /**
+     * Trino server host and port (e.g. {@code localhost:8080}).
+     * When {@code null}, remote validation is disabled.
+     */
+    @CommandLine.Option(
+        names = {"--server"},
+        description = "Trino server host:port for remote EXPLAIN (TYPE VALIDATE) (e.g. localhost:8080)")
+    private String server;
+
+    /**
+     * Trino user name. Defaults to the current OS user when not specified.
+     */
+    @CommandLine.Option(
+        names = {"--server-user"},
+        description = "Trino user name (default: current OS user)")
+    private String user;
+
+    /**
+     * Password for Basic authentication.
+     */
+    @CommandLine.Option(
+        names = {"--server-password"},
+        description = "Password for Basic authentication (prefer TRINO_PASSWORD env var)")
+    private String password;
+
+    /**
+     * Bearer access token for OAuth2 / JWT authentication.
+     */
+    @CommandLine.Option(
+        names = {"--server-access-token"},
+        description = "Bearer token for OAuth2/JWT authentication")
+    private String accessToken;
+
+    /**
+     * Enables SSL/TLS for the connection.
+     */
+    @CommandLine.Option(
+        names = {"--server-ssl"},
+        defaultValue = "false",
+        description = "Enable SSL/TLS for the Trino connection")
+    private boolean ssl;
+
+    /**
+     * Disables SSL certificate verification (development use only).
+     */
+    @CommandLine.Option(
+        names = {"--server-ssl-trust-all"},
+        defaultValue = "false",
+        description = "Disable SSL certificate verification (development only)")
+    private boolean sslTrustAll;
+
+    /**
+     * Timeout in seconds for the EXPLAIN (TYPE VALIDATE) request.
+     */
+    @CommandLine.Option(
+        names = {"--explain-timeout"},
+        defaultValue = "30",
+        description = "Timeout in seconds for EXPLAIN (TYPE VALIDATE) (default: 30)")
+    private int explainTimeout;
+
+    /**
+     * Returns the effective server address, resolving from the environment variable
+     * {@code TRINO_SERVER} when the option was not explicitly set.
+     *
+     * @return server host:port string, or {@code null} when absent
+     */
+    public String getServer() {
+        if (this.server != null) {
+            return this.server;
+        }
+        return System.getenv("TRINO_SERVER");
+    }
+
+    /**
+     * Returns the effective user name, resolving from the environment variable
+     * {@code TRINO_USER} or the current OS user name as a fallback.
+     *
+     * @return user name string (never null)
+     */
+    public String getUser() {
+        if (this.user != null) {
+            return this.user;
+        }
+        String envUser = System.getenv("TRINO_USER");
+        if (envUser != null) {
+            return envUser;
+        }
+        return System.getProperty("user.name");
+    }
+
+    /**
+     * Returns the effective password, resolving from the environment variable
+     * {@code TRINO_PASSWORD} when the option was not explicitly set.
+     *
+     * @return password string, or {@code null} when absent
+     */
+    public String getPassword() {
+        if (this.password != null) {
+            return this.password;
+        }
+        return System.getenv("TRINO_PASSWORD");
+    }
+
+    /**
+     * Returns the effective Bearer access token, resolving from the environment variable
+     * {@code TRINO_ACCESS_TOKEN} when the option was not explicitly set.
+     *
+     * @return access token string, or {@code null} when absent
+     */
+    public String getAccessToken() {
+        if (this.accessToken != null) {
+            return this.accessToken;
+        }
+        return System.getenv("TRINO_ACCESS_TOKEN");
+    }
+
+    /**
+     * Returns whether SSL/TLS should be enabled.
+     *
+     * @return {@code true} when SSL is enabled
+     */
+    public boolean isSsl() {
+        return this.ssl;
+    }
+
+    /**
+     * Returns whether SSL certificate verification should be disabled.
+     *
+     * @return {@code true} when trust-all is enabled
+     */
+    public boolean isSslTrustAll() {
+        return this.sslTrustAll;
+    }
+
+    /**
+     * Returns the EXPLAIN timeout in seconds.
+     *
+     * @return timeout in seconds
+     */
+    public int getExplainTimeout() {
+        return this.explainTimeout;
+    }
+
+    /**
+     * Returns {@code true} when remote validation is configured (i.e. {@code --server} is set
+     * or the {@code TRINO_SERVER} environment variable is present).
+     *
+     * @return {@code true} when a server address is available
+     */
+    public boolean isEnabled() {
+        return this.getServer() != null && !this.getServer().isBlank();
+    }
+
+    // Package-private setters for use in tests only.
+
+    void setServer(String server) {
+        this.server = server;
+    }
+
+    void setUser(String user) {
+        this.user = user;
+    }
+
+    void setPassword(String password) {
+        this.password = password;
+    }
+
+    void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    void setSsl(boolean ssl) {
+        this.ssl = ssl;
+    }
+
+    void setSslTrustAll(boolean sslTrustAll) {
+        this.sslTrustAll = sslTrustAll;
+    }
+
+    void setExplainTimeout(int explainTimeout) {
+        this.explainTimeout = explainTimeout;
+    }
+}

--- a/src/main/java/io/github/yuokada/subcommand/TrinoConnectionOptions.java
+++ b/src/main/java/io/github/yuokada/subcommand/TrinoConnectionOptions.java
@@ -29,10 +29,16 @@ public class TrinoConnectionOptions {
 
     /**
      * Password for Basic authentication.
+     * Specify without a value (e.g. {@code --server-password}) to be prompted interactively,
+     * avoiding exposure in shell history and process listings.
+     * The {@code TRINO_PASSWORD} environment variable is the recommended alternative for CI/CD.
      */
     @CommandLine.Option(
         names = {"--server-password"},
-        description = "Password for Basic authentication (prefer TRINO_PASSWORD env var)")
+        description = "Password for Basic authentication (prefer TRINO_PASSWORD env var)."
+            + " Omit the value to be prompted interactively.",
+        arity = "0..1",
+        interactive = true)
     private String password;
 
     /**

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeRemoteValidationTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeRemoteValidationTest.java
@@ -3,6 +3,7 @@ package io.github.yuokada.subcommand;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -149,13 +150,12 @@ class AnalyzeRemoteValidationTest {
 
     @Test
     void testConnectionOptions_noServerEnv_isDisabled() {
+        // Skip when TRINO_SERVER is set in the environment so the test is not flaky in CI.
+        assumeTrue(System.getenv("TRINO_SERVER") == null,
+            "Skipping: TRINO_SERVER is set in the environment");
+
         TrinoConnectionOptions opts = new TrinoConnectionOptions();
-        // TRINO_SERVER not set in test environment (no override)
-        // isEnabled() should be false when neither option nor env var is present
-        // (We can only assert when env var is genuinely absent)
-        if (System.getenv("TRINO_SERVER") == null) {
-            assertFalse(opts.isEnabled(),
-                "isEnabled() should be false when TRINO_SERVER is not set");
-        }
+        assertFalse(opts.isEnabled(),
+            "isEnabled() should be false when neither --server nor TRINO_SERVER is present");
     }
 }

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeRemoteValidationTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeRemoteValidationTest.java
@@ -1,0 +1,161 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests for the remote validation integration in the {@code analyze} subcommand.
+ *
+ * <p>These tests verify that:
+ * <ul>
+ *   <li>The existing static-analysis behavior is unchanged when {@code --server} is absent.</li>
+ *   <li>Phase 1 ERROR findings are present and Phase 2 is not attempted when errors exist.</li>
+ *   <li>On connection failure Phase 1 findings are still returned intact.</li>
+ * </ul>
+ *
+ * <p>Tests do not require a real Trino server; connection failures are expected and handled
+ * gracefully (Phase 2 skipped with a stderr message).
+ */
+class AnalyzeRemoteValidationTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    // ---- No --server: existing behaviour is unchanged -----------------------
+
+    @Test
+    void testNoServer_existingFindingsUnchanged(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT * FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        // W001 should still appear (SELECT *)
+        assertTrue(out.contains("W001"), "W001 should appear without --server: " + out);
+        // No E002–E005 or W004 without remote validation
+        assertFalse(out.contains("E002"), "No E002 without --server");
+        assertFalse(out.contains("E003"), "No E003 without --server");
+        assertFalse(out.contains("W004"), "No W004 without --server");
+    }
+
+    @Test
+    void testNoServer_exitCodeOk(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT id FROM t;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        int exitCode = analyze.call();
+
+        assertEquals(0, exitCode, "Exit code should be 0 without --server");
+    }
+
+    // ---- Phase 1 ERROR present: Phase 2 must NOT be attempted ---------------
+
+    @Test
+    void testPhase1Error_phase2Skipped(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        // DELETE without WHERE → E001 (ERROR)
+        Files.writeString(sql, "DELETE FROM t;");
+
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        // Point to a non-existent server; if Phase 2 were attempted, it would either
+        // fail fast (connection refused) or produce extra stderr output
+        opts.setServer("127.0.0.1:19998");
+        opts.setExplainTimeout(1);
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setServerOptions(opts);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        String err = errContent.toString(StandardCharsets.UTF_8);
+
+        assertTrue(out.contains("E001"), "E001 should appear: " + out);
+        // Phase 2 should NOT have been attempted (no connection error on stderr)
+        assertFalse(err.contains("[remote-validation]"),
+            "Phase 2 should be skipped when Phase 1 has ERROR: " + err);
+    }
+
+    // ---- Phase 1 WARNING only + unreachable server: Phase 1 findings intact -
+
+    @Test
+    void testPhase1Warning_unreachableServer_phase1FindingsReturned(
+            @TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT * FROM t;"); // W001
+
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        opts.setServer("127.0.0.1:19997"); // will fail to connect
+        opts.setExplainTimeout(1);
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setServerOptions(opts);
+        analyze.call();
+
+        String out = outContent.toString(StandardCharsets.UTF_8);
+        String err = errContent.toString(StandardCharsets.UTF_8);
+
+        // Phase 1 findings should still be present
+        assertTrue(out.contains("W001"), "W001 (Phase 1) should appear: " + out);
+        // Phase 2 was attempted but failed → stderr message expected
+        assertTrue(err.contains("[remote-validation]"),
+            "Remote validation should log connection error to stderr: " + err);
+        // No Phase 2 findings in output
+        assertFalse(out.contains("E002"), "No E002 on connection failure: " + out);
+        assertFalse(out.contains("E003"), "No E003 on connection failure: " + out);
+    }
+
+    // ---- TrinoConnectionOptions environment variable fallback ---------------
+
+    @Test
+    void testConnectionOptions_noServerEnv_isDisabled() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        // TRINO_SERVER not set in test environment (no override)
+        // isEnabled() should be false when neither option nor env var is present
+        // (We can only assert when env var is genuinely absent)
+        if (System.getenv("TRINO_SERVER") == null) {
+            assertFalse(opts.isEnabled(),
+                "isEnabled() should be false when TRINO_SERVER is not set");
+        }
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/TrinoRemoteValidatorTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/TrinoRemoteValidatorTest.java
@@ -1,0 +1,182 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.yuokada.core.LintFinding;
+import io.github.yuokada.core.QueryAnalyzer;
+import io.github.yuokada.core.QueryAnalysisResult;
+import io.github.yuokada.core.RemoteValidationResult;
+import io.github.yuokada.core.TrinoRemoteValidator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TrinoRemoteValidator} two-phase flow control logic.
+ *
+ * <p>These tests verify the gating logic (when Phase 2 is skipped) without making
+ * actual network connections. Remote-disabled and Phase-1-ERROR scenarios are covered.
+ */
+class TrinoRemoteValidatorTest {
+
+    // ---- Remote validation disabled (no --server) ----------------------------
+
+    @Test
+    void testNoServer_returnsPhase1Unchanged() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        // server not set → isEnabled() == false
+
+        QueryAnalysisResult phase1 = QueryAnalyzer.analyze(
+            "SELECT * FROM t", null, null, null, null);
+
+        QueryAnalysisResult result =
+            TrinoRemoteValidator.validate(phase1, "SELECT * FROM t", opts, null, null);
+
+        // Should be the exact same result object (no Phase 2 attempted)
+        assertSameFindingCount(phase1, result);
+    }
+
+    // ---- Phase 1 has ERROR → Phase 2 skipped ---------------------------------
+
+    @Test
+    void testPhase1HasError_phase2Skipped() {
+        // DELETE without WHERE → E001 (ERROR level)
+        QueryAnalysisResult phase1 = QueryAnalyzer.analyze(
+            "DELETE FROM t", null, null, null, null);
+
+        List<LintFinding> phase1Findings = phase1.getFindings();
+        boolean hasError = phase1Findings.stream()
+            .anyMatch(f -> f.getSeverity() == LintFinding.Severity.ERROR);
+        assertTrue(hasError, "Phase 1 should have E001 error finding");
+
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        opts.setServer("localhost:9999"); // server configured but should be skipped
+
+        QueryAnalysisResult result =
+            TrinoRemoteValidator.validate(phase1, "DELETE FROM t", opts, null, null);
+
+        // Finding count must equal Phase 1 only (no remote findings added)
+        assertSameFindingCount(phase1, result);
+    }
+
+    // ---- Phase 1 WARNING only → Phase 2 would run (but server unreachable) --
+
+    @Test
+    void testPhase1WarningOnly_phase2AttemptedButSkippedOnConnectionFailure() {
+        // SELECT * → W001 (WARNING only, no ERROR)
+        QueryAnalysisResult phase1 = QueryAnalyzer.analyze(
+            "SELECT * FROM t", null, null, null, null);
+
+        List<LintFinding> phase1Findings = phase1.getFindings();
+        assertFalse(
+            phase1Findings.stream().anyMatch(f -> f.getSeverity() == LintFinding.Severity.ERROR),
+            "Phase 1 should have no ERROR findings");
+
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        // Use an address that will fail to connect immediately
+        opts.setServer("127.0.0.1:19999");
+        opts.setExplainTimeout(1); // 1 second timeout for fast failure
+
+        QueryAnalysisResult result =
+            TrinoRemoteValidator.validate(phase1, "SELECT * FROM t", opts, null, null);
+
+        // Connection will fail → Phase 2 returns skipped → Phase 1 findings only
+        assertEquals(phase1.getFindings().size(), result.getFindings().size(),
+            "On connection failure Phase 2 should be skipped, returning Phase 1 findings only");
+    }
+
+    // ---- withRemoteFindings preserves Phase 1 data ---------------------------
+
+    @Test
+    void testWithRemoteFindings_appendsToPhase1() {
+        QueryAnalysisResult phase1 = QueryAnalyzer.analyze(
+            "SELECT * FROM t", null, null, null, null);
+        int phase1Count = phase1.getFindings().size(); // W001
+
+        List<LintFinding> remoteFinding = List.of(
+            new LintFinding("E002", LintFinding.Severity.ERROR,
+                "Table not found: mycat.s.t"));
+
+        QueryAnalysisResult combined = phase1.withRemoteFindings(remoteFinding);
+
+        assertEquals(phase1Count + 1, combined.getFindings().size(),
+            "Combined result should have Phase 1 + 1 remote finding");
+
+        LintFinding last = combined.getFindings().get(combined.getFindings().size() - 1);
+        assertEquals("E002", last.getRuleId());
+        assertEquals(LintFinding.Severity.ERROR, last.getSeverity());
+        assertTrue(last.getMessage().contains("Table not found"));
+    }
+
+    // ---- withRemoteFindings with null list -----------------------------------
+
+    @Test
+    void testWithRemoteFindings_nullList_isNoop() {
+        QueryAnalysisResult phase1 = QueryAnalyzer.analyze(
+            "SELECT id FROM t", null, null, null, null);
+        int phase1Count = phase1.getFindings().size();
+
+        QueryAnalysisResult result = phase1.withRemoteFindings(null);
+        assertEquals(phase1Count, result.getFindings().size(),
+            "withRemoteFindings(null) should not change finding count");
+    }
+
+    // ---- RemoteValidationResult factory methods ------------------------------
+
+    @Test
+    void testRemoteValidationResult_valid() {
+        RemoteValidationResult r = RemoteValidationResult.valid();
+        assertFalse(r.isSkipped());
+        assertTrue(r.getFindings().isEmpty());
+    }
+
+    @Test
+    void testRemoteValidationResult_failed() {
+        List<LintFinding> findings = List.of(
+            new LintFinding("E003", LintFinding.Severity.ERROR, "Column not found: x"));
+        RemoteValidationResult r = RemoteValidationResult.failed(findings);
+        assertFalse(r.isSkipped());
+        assertEquals(1, r.getFindings().size());
+        assertEquals("E003", r.getFindings().get(0).getRuleId());
+    }
+
+    @Test
+    void testRemoteValidationResult_skipped() {
+        RemoteValidationResult r = RemoteValidationResult.skipped();
+        assertTrue(r.isSkipped());
+        assertTrue(r.getFindings().isEmpty());
+    }
+
+    // ---- TrinoConnectionOptions --server / isEnabled -------------------------
+
+    @Test
+    void testConnectionOptions_notEnabled_whenServerAbsent() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        assertFalse(opts.isEnabled());
+    }
+
+    @Test
+    void testConnectionOptions_enabled_whenServerSet() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        opts.setServer("localhost:8080");
+        assertTrue(opts.isEnabled());
+    }
+
+    @Test
+    void testConnectionOptions_defaultUser_fallsBackToSystemUser() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        String user = opts.getUser();
+        // Should be non-null (system user or env variable)
+        assertTrue(user != null && !user.isBlank(),
+            "Default user should fall back to system user");
+    }
+
+    // ---- helper --------------------------------------------------------------
+
+    private static void assertSameFindingCount(QueryAnalysisResult expected,
+                                               QueryAnalysisResult actual) {
+        assertEquals(expected.getFindings().size(), actual.getFindings().size(),
+            "Finding count should be unchanged");
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces **two-phase validation** to the `analyze` subcommand:
  - **Phase 1** — existing local static analysis (W001–W003, E001); unchanged
  - **Phase 2** — remote `EXPLAIN (TYPE VALIDATE)` via `io.trino:trino-client`, executed only when Phase 1 produces **no ERROR-level findings**
- Adds `--server` and related connection options; remote validation is opt-in (no breaking changes)
- Adds new lint rules E002–E005 and W004 sourced from Trino server error responses

## New Options (`analyze` subcommand)

| Option | Description |
|---|---|
| `--server <host:port>` | Trino server address (enables Phase 2) |
| `--server-user <name>` | User name (default: OS user / `TRINO_USER`) |
| `--server-password <pw>` | Password for Basic auth (prefer `TRINO_PASSWORD` env var) |
| `--server-access-token <token>` | Bearer token for OAuth2/JWT |
| `--server-ssl` | Enable SSL/TLS |
| `--server-ssl-trust-all` | Disable cert verification (dev only) |
| `--explain-timeout <sec>` | Timeout in seconds (default: 30) |

Environment variables `TRINO_SERVER`, `TRINO_USER`, `TRINO_PASSWORD`, `TRINO_ACCESS_TOKEN` are supported as fallbacks.

## New Lint Rules (Phase 2)

| Rule | Severity | Trigger |
|---|---|---|
| E002 | ERROR | `TABLE_NOT_FOUND` |
| E003 | ERROR | `COLUMN_NOT_FOUND` |
| E004 | ERROR | `FUNCTION_NOT_FOUND` |
| E005 | ERROR | `TYPE_MISMATCH` |
| W004 | WARNING | Other `USER_ERROR` from server |

## New Classes

| Class | Role |
|---|---|
| `TrinoConnectionOptions` | Picocli `@ArgGroup` for all server connection options |
| `TrinoExplainClient` | `trino-client` wrapper; executes `EXPLAIN (TYPE VALIDATE)` and converts `QueryError` to `LintFinding` |
| `TrinoRemoteValidator` | Two-phase orchestrator; skips Phase 2 when Phase 1 has errors |
| `RemoteValidationResult` | `valid()` / `failed()` / `skipped()` result container |

## Test plan

- [x] `TrinoRemoteValidatorTest` — 11 tests for two-phase gating logic (no real server required)
- [x] `AnalyzeRemoteValidationTest` — 5 integration tests (Phase 1 error skips Phase 2, connection failure returns Phase 1 findings intact)
- [x] All 198 tests pass (`./mvnw verify`)
- [x] Checkstyle passes

## References

- Spec: `docs/remote-validation-spec.md`
- Trino `EXPLAIN (TYPE VALIDATE)` docs: https://trino.io/docs/435/sql/explain.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)