### PR TITLE
Add Testcontainers integration tests for remote validation (E002–E005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,26 @@ java -jar ... --quiet format --check query.sql
 ./mvnw package -Dnative -Dquarkus.native.container-build=true
 ```
 
+### Integration tests (Docker required)
+
+The integration tests in `TrinoExplainClientContainerTest` and `AnalyzeCommandContainerTest`
+start a real Trino 435 container via [Testcontainers](https://testcontainers.com/) to verify
+the end-to-end `EXPLAIN (TYPE VALIDATE)` flow. They are skipped automatically when Docker is
+not available.
+
+```bash
+# Start Docker Desktop (macOS), then:
+
+# Run only the integration tests
+./mvnw test -Dtest="TrinoExplainClientContainerTest,AnalyzeCommandContainerTest"
+
+# Run the full suite including integration tests
+./mvnw verify
+```
+
+The first run pulls the `trinodb/trino:435` image (~700 MB). Subsequent runs reuse the cached
+image. The container is started once per test class and stopped when the class finishes.
+
 The über-jar is produced at `target/trino-query-formatter-1.0.0-SNAPSHOT-runner.jar`.
 
 For more information on Quarkus, see <https://quarkus.io/>.

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <git-commit-id-plugin.version>9.0.2</git-commit-id-plugin.version>
         <!-- App specific properties -->
         <trino.version>435</trino.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
     </properties>
 
     <scm>
@@ -93,6 +94,24 @@
             <artifactId>antlr4-runtime</artifactId>
             <version>4.13.2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>trino</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-jdbc</artifactId>
+            <version>${trino.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <trino.version>${trino.version}</trino.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeCommandContainerTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeCommandContainerTest.java
@@ -1,0 +1,162 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end integration tests for the {@code analyze} subcommand with a real
+ * Trino server started via Testcontainers.
+ *
+ * <p>These tests verify that:
+ * <ul>
+ *   <li>Phase 2 remote validation is performed against a live Trino instance.</li>
+ *   <li>E002 is present in the output when a table is not found on the server.</li>
+ *   <li>Phase 2 is skipped when Phase 1 has ERROR-level findings (E001).</li>
+ *   <li>JSON output is well-formed and parseable.</li>
+ * </ul>
+ *
+ * <p>Requires Docker to be available. All tests are skipped automatically when Docker
+ * is not reachable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class AnalyzeCommandContainerTest {
+
+    @Container
+    private static final TrinoContainer TRINO = new TrinoContainer("trinodb/trino:435");
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(this.outContent));
+        System.setErr(new PrintStream(this.errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(this.originalOut);
+        System.setErr(this.originalErr);
+    }
+
+    // ---- Valid query: no remote findings ------------------------------------
+
+    @Test
+    void testValidQuery_noRemoteFindings(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT nationkey FROM nation;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setDefaultCatalog("tpch");
+        analyze.setDefaultSchema("tiny");
+        analyze.setServerOptions(buildOpts());
+        analyze.call();
+
+        String out = this.outContent.toString(StandardCharsets.UTF_8);
+        assertFalse(out.contains("E002"), "Valid query should not produce E002: " + out);
+        assertFalse(out.contains("E003"), "Valid query should not produce E003: " + out);
+        assertFalse(out.contains("E004"), "Valid query should not produce E004: " + out);
+        assertFalse(out.contains("E005"), "Valid query should not produce E005: " + out);
+    }
+
+    // ---- Invalid table: E002 in output -------------------------------------
+
+    @Test
+    void testInvalidTable_E002InOutput(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT id FROM missing_table_xyz;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setDefaultCatalog("tpch");
+        analyze.setDefaultSchema("tiny");
+        analyze.setServerOptions(buildOpts());
+        analyze.call();
+
+        String out = this.outContent.toString(StandardCharsets.UTF_8);
+        assertTrue(out.contains("E002"),
+            "TABLE_NOT_FOUND should produce E002 in output: " + out);
+    }
+
+    // ---- Phase 1 ERROR: Phase 2 must not be attempted ----------------------
+
+    @Test
+    void testPhase1Error_phase2NotAttempted(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        // DELETE without WHERE → E001 (ERROR) from Phase 1
+        Files.writeString(sql, "DELETE FROM nation;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setDefaultCatalog("tpch");
+        analyze.setDefaultSchema("tiny");
+        analyze.setServerOptions(buildOpts());
+        analyze.call();
+
+        String out = this.outContent.toString(StandardCharsets.UTF_8);
+        String err = this.errContent.toString(StandardCharsets.UTF_8);
+
+        assertTrue(out.contains("E001"),
+            "DELETE without WHERE should produce E001: " + out);
+        assertFalse(out.contains("E002"),
+            "Phase 2 should not run when Phase 1 has ERROR: " + out);
+        assertFalse(err.contains("[remote-validation]"),
+            "No [remote-validation] stderr when Phase 1 has ERROR: " + err);
+    }
+
+    // ---- JSON output is well-formed ----------------------------------------
+
+    @Test
+    void testValidQuery_jsonOutputIsParseable(@TempDir Path tempDir) throws IOException {
+        Path sql = tempDir.resolve("q.sql");
+        Files.writeString(sql, "SELECT COUNT(*) FROM nation;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sql.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("full");
+        analyze.setDefaultCatalog("tpch");
+        analyze.setDefaultSchema("tiny");
+        analyze.setServerOptions(buildOpts());
+        analyze.call();
+
+        String out = this.outContent.toString(StandardCharsets.UTF_8);
+        ObjectMapper mapper = new ObjectMapper();
+        assertDoesNotThrow(() -> mapper.readTree(out),
+            "Output should be valid JSON: " + out);
+    }
+
+    // ---- Helper -------------------------------------------------------------
+
+    private static TrinoConnectionOptions buildOpts() {
+        TrinoConnectionOptions opts = new TrinoConnectionOptions();
+        opts.setServer(TRINO.getHost() + ":" + TRINO.getMappedPort(8080));
+        opts.setUser(TRINO.getUsername());
+        return opts;
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeCommandContainerTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeCommandContainerTest.java
@@ -1,5 +1,6 @@
 package io.github.yuokada.subcommand;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,8 +38,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class AnalyzeCommandContainerTest {
 
+    private static final String TRINO_IMAGE =
+        "trinodb/trino:" + System.getProperty("trino.version", "435");
+
     @Container
-    private static final TrinoContainer TRINO = new TrinoContainer("trinodb/trino:435");
+    private static final TrinoContainer TRINO = new TrinoContainer(TRINO_IMAGE);
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
@@ -74,10 +78,12 @@ class AnalyzeCommandContainerTest {
         analyze.call();
 
         String out = this.outContent.toString(StandardCharsets.UTF_8);
-        assertFalse(out.contains("E002"), "Valid query should not produce E002: " + out);
-        assertFalse(out.contains("E003"), "Valid query should not produce E003: " + out);
-        assertFalse(out.contains("E004"), "Valid query should not produce E004: " + out);
-        assertFalse(out.contains("E005"), "Valid query should not produce E005: " + out);
+        assertAll(
+            () -> assertFalse(out.contains("E002"), "Valid query should not produce E002: " + out),
+            () -> assertFalse(out.contains("E003"), "Valid query should not produce E003: " + out),
+            () -> assertFalse(out.contains("E004"), "Valid query should not produce E004: " + out),
+            () -> assertFalse(out.contains("E005"), "Valid query should not produce E005: " + out)
+        );
     }
 
     // ---- Invalid table: E002 in output -------------------------------------

--- a/src/test/java/io/github/yuokada/subcommand/TrinoExplainClientContainerTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/TrinoExplainClientContainerTest.java
@@ -1,0 +1,143 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.yuokada.core.LintFinding;
+import io.github.yuokada.core.RemoteValidationResult;
+import io.github.yuokada.core.TrinoExplainClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration tests for {@link TrinoExplainClient} against a real Trino server
+ * started via Testcontainers.
+ *
+ * <p>These tests verify that {@code EXPLAIN (TYPE VALIDATE)} requests are sent correctly
+ * to Trino and that server error responses are mapped to the expected
+ * {@link LintFinding} rule IDs (E002–E005).
+ *
+ * <p>Requires Docker to be available. All tests are skipped automatically when Docker
+ * is not reachable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class TrinoExplainClientContainerTest {
+
+    @Container
+    private static final TrinoContainer TRINO = new TrinoContainer("trinodb/trino:435");
+
+    private TrinoConnectionOptions opts;
+
+    @BeforeEach
+    void setUp() {
+        this.opts = new TrinoConnectionOptions();
+        this.opts.setServer(TRINO.getHost() + ":" + TRINO.getMappedPort(8080));
+        this.opts.setUser(TRINO.getUsername());
+    }
+
+    // ---- Valid queries -------------------------------------------------------
+
+    @Test
+    void testValidQuery_returnsValid() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result = client.validate("SELECT nationkey, name FROM nation");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertTrue(result.getFindings().isEmpty(),
+                "Valid query should produce no findings: " + result.getFindings());
+        }
+    }
+
+    @Test
+    void testValidAggregate_returnsValid() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result = client.validate("SELECT COUNT(*) FROM nation");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertTrue(result.getFindings().isEmpty(),
+                "Valid aggregate should produce no findings: " + result.getFindings());
+        }
+    }
+
+    // ---- E002: TABLE_NOT_FOUND ----------------------------------------------
+
+    @Test
+    void testTableNotFound_producesE002() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result =
+                client.validate("SELECT id FROM nonexistent_table_xyz");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertFalse(result.getFindings().isEmpty(),
+                "TABLE_NOT_FOUND should produce a finding");
+            assertEquals("E002", result.getFindings().get(0).getRuleId(),
+                "TABLE_NOT_FOUND should map to rule E002");
+            assertEquals(LintFinding.Severity.ERROR, result.getFindings().get(0).getSeverity(),
+                "E002 should have ERROR severity");
+        }
+    }
+
+    // ---- E003: COLUMN_NOT_FOUND --------------------------------------------
+
+    @Test
+    void testColumnNotFound_producesE003() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result =
+                client.validate("SELECT nonexistent_col_xyz FROM nation");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertFalse(result.getFindings().isEmpty(),
+                "COLUMN_NOT_FOUND should produce a finding");
+            assertEquals("E003", result.getFindings().get(0).getRuleId(),
+                "COLUMN_NOT_FOUND should map to rule E003");
+            assertEquals(LintFinding.Severity.ERROR, result.getFindings().get(0).getSeverity(),
+                "E003 should have ERROR severity");
+        }
+    }
+
+    // ---- E004: FUNCTION_NOT_FOUND ------------------------------------------
+
+    @Test
+    void testFunctionNotFound_producesE004() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result =
+                client.validate("SELECT my_unknown_xyz_func_99(1)");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertFalse(result.getFindings().isEmpty(),
+                "FUNCTION_NOT_FOUND should produce a finding");
+            assertEquals("E004", result.getFindings().get(0).getRuleId(),
+                "FUNCTION_NOT_FOUND should map to rule E004");
+            assertEquals(LintFinding.Severity.ERROR, result.getFindings().get(0).getSeverity(),
+                "E004 should have ERROR severity");
+        }
+    }
+
+    // ---- E005: TYPE_MISMATCH -----------------------------------------------
+
+    @Test
+    void testTypeMismatch_producesE005() {
+        // nationkey is BIGINT, name is VARCHAR — adding them produces TYPE_MISMATCH
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            RemoteValidationResult result =
+                client.validate("SELECT nationkey + name FROM nation");
+            assertFalse(result.isSkipped(), "Result should not be skipped");
+            assertFalse(result.getFindings().isEmpty(),
+                "TYPE_MISMATCH should produce a finding");
+            assertEquals("E005", result.getFindings().get(0).getRuleId(),
+                "TYPE_MISMATCH should map to rule E005");
+            assertEquals(LintFinding.Severity.ERROR, result.getFindings().get(0).getSeverity(),
+                "E005 should have ERROR severity");
+        }
+    }
+
+    // ---- Null SQL guard -----------------------------------------------------
+
+    @Test
+    void testNullSql_throwsIllegalArgumentException() {
+        try (TrinoExplainClient client = TrinoExplainClient.create(this.opts, "tpch", "tiny")) {
+            assertThrows(IllegalArgumentException.class, () -> client.validate(null),
+                "validate(null) should throw IllegalArgumentException");
+        }
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/TrinoExplainClientContainerTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/TrinoExplainClientContainerTest.java
@@ -28,8 +28,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class TrinoExplainClientContainerTest {
 
+    private static final String TRINO_IMAGE =
+        "trinodb/trino:" + System.getProperty("trino.version", "435");
+
     @Container
-    private static final TrinoContainer TRINO = new TrinoContainer("trinodb/trino:435");
+    private static final TrinoContainer TRINO = new TrinoContainer(TRINO_IMAGE);
 
     private TrinoConnectionOptions opts;
 


### PR DESCRIPTION
## Summary

- Adds two new integration test classes that spin up a real **Trino 435** container via Testcontainers to verify the `EXPLAIN (TYPE VALIDATE)` flow end-to-end.
- All tests skip automatically when Docker is not available (`@Testcontainers(disabledWithoutDocker = true)`).
- No changes to production code.

### New test classes

**`TrinoExplainClientContainerTest`** (7 tests — in `subcommand` package to access package-private setters):
| Test | SQL | Expected |
|---|---|---|
| `testValidQuery_returnsValid` | `SELECT nationkey, name FROM nation` | `valid()`, empty findings |
| `testValidAggregate_returnsValid` | `SELECT COUNT(*) FROM nation` | `valid()`, empty findings |
| `testTableNotFound_producesE002` | `SELECT id FROM nonexistent_table_xyz` | `failed()`, ruleId=E002 |
| `testColumnNotFound_producesE003` | `SELECT nonexistent_col_xyz FROM nation` | `failed()`, ruleId=E003 |
| `testFunctionNotFound_producesE004` | `SELECT my_unknown_xyz_func_99(1)` | `failed()`, ruleId=E004 |
| `testTypeMismatch_producesE005` | `SELECT nationkey + name FROM nation` | `failed()`, ruleId=E005 |
| `testNullSql_throwsIllegalArgumentException` | `null` | `IllegalArgumentException` |

**`AnalyzeCommandContainerTest`** (4 tests — end-to-end `Analyze` command):
| Test | SQL | Expected |
|---|---|---|
| `testValidQuery_noRemoteFindings` | `SELECT nationkey FROM nation` | No E002–E005 in JSON output |
| `testInvalidTable_E002InOutput` | `SELECT id FROM missing_table_xyz` | E002 in JSON output |
| `testPhase1Error_phase2NotAttempted` | `DELETE FROM nation` | E001 only; no `[remote-validation]` on stderr |
| `testValidQuery_jsonOutputIsParseable` | `SELECT COUNT(*) FROM nation` | JSON is well-formed |

### Dependencies added (test scope)

```xml
<dependency>org.testcontainers:trino:1.21.4</dependency>
<dependency>org.testcontainers:junit-jupiter:1.21.4</dependency>
<dependency>io.trino:trino-jdbc:435</dependency>
```

## Test plan

- [x] `./mvnw verify` passes (209 tests, 11 skipped without Docker, 0 failures)
- [x] Checkstyle passes
- [ ] Run `./mvnw test -Dtest="TrinoExplainClientContainerTest,AnalyzeCommandContainerTest"` with Docker running to verify all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)