### PR TITLE
Add GitHub Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,8 @@ Follow these repository instructions when working in this project.
 
 - Production code lives under `src/main/java/io/github/yuokada`.
 - Tests live under `src/test/java` and test resources live under `src/test/resources`.
-- Sample SQL files and fixtures live under `src/main/resources/queries` and `src/test/resources/queries`.
+- Sample SQL files live under `src/main/resources/queries`.
+- Test fixtures (including SQL files) live under `src/test/resources/queries`.
 - Maven Wrapper is the standard entry point for build and test commands.
 
 ## Validation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# GitHub Copilot Instructions
+
+Follow these repository instructions when working in this project.
+
+## General guidance
+
+- Keep changes focused and consistent with the existing Java 17, Quarkus, and Picocli CLI architecture.
+- Write all new or updated repository instructions, code comments, and documentation edits in English.
+- Avoid machine-specific paths, local-only assumptions, and environment-dependent behavior unless explicitly required.
+- Preserve the current command-line interface and output behavior unless the task explicitly changes user-facing behavior.
+- Keep diffs small and avoid unrelated refactors.
+
+## Project context
+
+- Production code lives under `src/main/java/io/github/yuokada`.
+- Tests live under `src/test/java` and test resources live under `src/test/resources`.
+- Sample SQL files and fixtures live under `src/main/resources/queries` and `src/test/resources/queries`.
+- Maven Wrapper is the standard entry point for build and test commands.
+
+## Validation
+
+- Prefer `./mvnw validate` for style and structural checks.
+- Prefer `./mvnw test` for unit and integration-relevant test coverage in the default profile.
+- If a change affects packaging or runtime behavior, consider `./mvnw package` as an additional verification step.
+- Clearly separate checks you executed from checks you did not execute.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "README.md,pom.xml,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
+---
+
+When editing documentation, build metadata, or workflow files in this repository:
+
+- Keep examples, version references, and command snippets consistent with `pom.xml` and the actual CLI behavior.
+- Use portable commands and avoid references to local absolute paths or developer-specific environments.
+- When changing build or release behavior, preserve the Maven Wrapper based workflow unless there is a clear reason to change it.
+- If user-facing CLI behavior changes, update `README.md` in the same change.

--- a/.github/instructions/java.instructions.md
+++ b/.github/instructions/java.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "src/main/java/**/*.java"
+---
+
+When editing Java source files in this repository:
+
+- Preserve the existing package layout under `io.github.yuokada`.
+- Keep command handling in the Picocli command layer and reusable SQL logic in dedicated core classes.
+- Target Java 17 and existing Quarkus conventions already used in the project.
+- Follow the repository formatting and style expectations enforced by Checkstyle, including explicit imports and readable line lengths.
+- Prefer focused changes that do not alter CLI semantics unless the task explicitly requires it.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "src/test/java/**/*.java,src/test/resources/**/*.sql,src/test/resources/**/*.txt,src/main/resources/queries/**/*.sql"
+---
+
+When editing tests or SQL fixtures in this repository:
+
+- Keep test inputs and expected outputs easy to read and representative of real Trino SQL usage.
+- Prefer extending existing test coverage near the affected behavior instead of adding disconnected tests.
+- Update golden files or SQL fixtures only when the intended formatter or analyzer behavior changes.
+- Preserve deterministic assertions so tests remain stable across environments.


### PR DESCRIPTION
## Summary
- add repository-wide GitHub Copilot instructions
- add path-specific instruction files for Java sources, tests, and docs/workflows
- keep all instruction content in English and avoid local absolute paths

## Testing
- not run (instruction files only)