### PR TITLE
Implement phase A CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Quarkus, Picocli, and the `trino-parser`/`trino-cli` libraries.
 # Format a file
 java -jar target/trino-query-formatter-1.0.0-SNAPSHOT-runner.jar format query.sql
 
+# Show extended build/runtime metadata
+java -jar target/trino-query-formatter-1.0.0-SNAPSHOT-runner.jar --version --verbose
+
 # Read from stdin, write to stdout
 cat query.sql | java -jar target/trino-query-formatter-1.0.0-SNAPSHOT-runner.jar format -
 
@@ -193,6 +196,8 @@ analyze --details full query.sql
 # Flags: usesSelectStar=false, hasLimit=true, hasWhereOnDelete=null
 # Functions: scalar=[lower], aggregate=[count], window=[]
 # Lint: [WARNING] W001: SELECT * detected; prefer explicit column list
+#   Why: SELECT * couples queries to the table schema; adding a column can break consumers.
+#   Fix: List only the columns you need instead of using SELECT *.
 ```
 
 ### JSON output (full details)
@@ -202,8 +207,67 @@ analyze --format json --details full query.sql
 ```
 
 ```json
-{"queryType":"Query","catalogs":["catalog1"],"tables":["catalog1.s.orders"],"usesSelectStar":true,"ctes":[],"joins":[],"functionsScalar":[],"functionsAggregate":[],"functionsWindow":[],"writeTargets":[],"findings":[{"ruleId":"W001","severity":"WARNING","message":"SELECT * detected; prefer explicit column list"}],"hasLimit":false}
+{"queryType":"Query","catalogs":["catalog1"],"tables":["catalog1.s.orders"],"usesSelectStar":true,"ctes":[],"joins":[],"functionsScalar":[],"functionsAggregate":[],"functionsWindow":[],"writeTargets":[],"findings":[{"ruleId":"W001","severity":"WARNING","message":"SELECT * detected; prefer explicit column list","hint":"SELECT * couples queries to the table schema; adding a column can break consumers.","fix":"List only the columns you need instead of using SELECT *."}],"hasLimit":false}
 ```
+
+### Helpful option validation
+
+The CLI now emits explicit guidance for common option combinations:
+
+```bash
+analyze --format json --details basic query.sql
+# stderr: Warning: --details basic suppresses extended fields; use --details full for complete JSON.
+
+analyze --udf-catalog udf.yml query.sql
+# stderr: Info: --udf-catalog implies function existence checking; pass --validate-functions to also enable W002.
+```
+
+Missing files are also reported without a Java stack trace:
+
+```bash
+format missing.sql
+# stderr: Error: SQL file not found: missing.sql
+```
+
+## Shell completion
+
+The CLI provides a built-in `generate-completion` subcommand.
+
+### Bash
+
+```bash
+source <(trino-query-formatter generate-completion --shell bash)
+```
+
+To install it permanently:
+
+```bash
+trino-query-formatter generate-completion --shell bash > ~/.bash_completion.d/trino-query-formatter
+```
+
+### Zsh
+
+The generated script is bash-compatible and works in Zsh via `bashcompinit`.
+
+```bash
+autoload -U +X bashcompinit && bashcompinit
+source <(trino-query-formatter generate-completion --shell zsh)
+```
+
+To install it permanently:
+
+```bash
+autoload -U +X bashcompinit && bashcompinit
+trino-query-formatter generate-completion --shell zsh > ~/.zsh/completions/_trino-query-formatter
+```
+
+### Fish
+
+```bash
+trino-query-formatter generate-completion --shell fish > ~/.config/fish/completions/trino-query-formatter.fish
+```
+
+Example loader scripts are committed under [`completions/`](completions/).
 
 ### Multiple statements are rejected
 

--- a/completions/_trino-query-formatter
+++ b/completions/_trino-query-formatter
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+# Example loader for Zsh completion.
+autoload -U +X bashcompinit && bashcompinit
+source <(trino-query-formatter generate-completion --shell zsh)

--- a/completions/trino-query-formatter.bash
+++ b/completions/trino-query-formatter.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Example loader for Bash completion.
+source <(trino-query-formatter generate-completion --shell bash)

--- a/completions/trino-query-formatter.fish
+++ b/completions/trino-query-formatter.fish
@@ -1,0 +1,2 @@
+# Example loader for Fish completion.
+trino-query-formatter generate-completion --shell fish | source

--- a/src/main/java/io/github/yuokada/EntryCommand.java
+++ b/src/main/java/io/github/yuokada/EntryCommand.java
@@ -2,21 +2,28 @@ package io.github.yuokada;
 
 import io.github.yuokada.subcommand.Analyze;
 import io.github.yuokada.subcommand.Format;
+import io.github.yuokada.subcommand.GenerateCompletion;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.ParseResult;
 
 @TopCommand
 @CommandLine.Command(
     name = "trino-query-formatter",
     subcommands = {
         Analyze.class,
-        Format.class
+        Format.class,
+        GenerateCompletion.class
     },
     mixinStandardHelpOptions = true,
     versionProvider = GitVersionProvider.class,
+    exitCodeOnUsageHelp = ExitCode.OK,
+    exitCodeOnVersionHelp = ExitCode.OK,
     description = "Tool to format SQL queries for Trino.")
 public class EntryCommand implements Callable<Integer> {
 
@@ -33,14 +40,32 @@ public class EntryCommand implements Callable<Integer> {
     private boolean quiet;
 
     /**
+     * Explicit version flag so the command can customize verbose version output.
+     */
+    @CommandLine.Option(names = {"-V", "--version"}, versionHelp = true,
+        description = "Print version information and exit.")
+    private boolean versionRequested;
+
+    /**
      * Main entry point for the command-line application.
      *
      * @param args Command-line arguments.
      * @throws IOException If an I/O error occurs.
      */
     public static void main(String[] args) throws IOException {
-        int exitCode = new CommandLine(new EntryCommand()).execute(args);
+        int exitCode = newCommandLine().execute(args);
         System.exit(exitCode);
+    }
+
+    /**
+     * Builds a configured command line with custom verbose version handling.
+     *
+     * @return configured command line
+     */
+    public static CommandLine newCommandLine() {
+        CommandLine commandLine = new CommandLine(new EntryCommand());
+        commandLine.setExecutionStrategy(EntryCommand::executeWithVersionHelp);
+        return commandLine;
     }
 
     /**
@@ -54,6 +79,43 @@ public class EntryCommand implements Callable<Integer> {
         CommandLine.usage(this, System.out);
         // Quarkus.waitForExit();
         return ExitCode.OK;
+    }
+
+    private static int executeWithVersionHelp(ParseResult parseResult) {
+        ParseResult root = parseResult;
+        if (root.isVersionHelpRequested() && !root.hasSubcommand()) {
+            EntryCommand command = (EntryCommand) root.commandSpec().userObject();
+            PrintWriter out = root.commandSpec().commandLine().getOut();
+            if (command.isVerbose()) {
+                printVerboseVersion(out);
+            } else {
+                root.commandSpec().commandLine().printVersionHelp(out);
+            }
+            out.flush();
+            return ExitCode.OK;
+        }
+        Integer helpResult = CommandLine.executeHelpRequest(parseResult);
+        if (helpResult != null) {
+            return ExitCode.OK;
+        }
+        return new CommandLine.RunLast().execute(parseResult);
+    }
+
+    private static void printVerboseVersion(PrintWriter out) {
+        Properties gitProperties = VersionMetadata.gitProperties();
+        out.println("trino-query-formatter " + VersionMetadata.applicationVersion());
+        out.println("  Git commit  : "
+            + gitProperties.getProperty("git.commit.id.abbrev", VersionMetadata.UNKNOWN));
+        out.println("  Build date  : "
+            + gitProperties.getProperty("git.build.time", VersionMetadata.UNKNOWN));
+        out.println("  Java runtime: " + System.getProperty("java.version", VersionMetadata.UNKNOWN)
+            + " (" + System.getProperty("java.vendor", VersionMetadata.UNKNOWN) + ")");
+        out.println("  Quarkus     : "
+            + VersionMetadata.dependencyVersion("io.quarkus", "quarkus-picocli"));
+        out.println("  trino-parser: "
+            + VersionMetadata.dependencyVersion("io.trino", "trino-parser"));
+        out.println("  trino-cli   : "
+            + VersionMetadata.dependencyVersion("io.trino", "trino-cli"));
     }
 
     /**

--- a/src/main/java/io/github/yuokada/GitVersionProvider.java
+++ b/src/main/java/io/github/yuokada/GitVersionProvider.java
@@ -1,9 +1,5 @@
 package io.github.yuokada;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import org.eclipse.microprofile.config.ConfigProvider;
 import picocli.CommandLine.IVersionProvider;
 
 /**
@@ -11,42 +7,10 @@ import picocli.CommandLine.IVersionProvider;
  */
 public class GitVersionProvider implements IVersionProvider {
 
-    /**
-     * Fallback value used when git metadata is unavailable.
-     */
-    private static final String UNKNOWN = "unknown";
-
     @Override
     public String[] getVersion() throws Exception {
-        Properties properties = loadGitProperties();
-        String appVersion = resolveApplicationVersion();
-        String commitId = properties.getProperty("git.commit.id.abbrev", UNKNOWN);
         return new String[] {
-            String.format("trino-query-formatter %s (%s)", appVersion, commitId)
+            String.format("trino-query-formatter %s", VersionMetadata.applicationVersion())
         };
-    }
-
-    private static String resolveApplicationVersion() {
-        try {
-            return ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.application.version", String.class)
-                .filter(value -> !value.isBlank())
-                .orElse(UNKNOWN);
-        } catch (RuntimeException ignored) {
-            return UNKNOWN;
-        }
-    }
-
-    private static Properties loadGitProperties() {
-        Properties properties = new Properties();
-        try (InputStream input = GitVersionProvider.class.getClassLoader()
-            .getResourceAsStream("git.properties")) {
-            if (input != null) {
-                properties.load(input);
-            }
-        } catch (IOException ignored) {
-            // Fall back to default "unknown" values when git.properties cannot be loaded.
-        }
-        return properties;
     }
 }

--- a/src/main/java/io/github/yuokada/VersionMetadata.java
+++ b/src/main/java/io/github/yuokada/VersionMetadata.java
@@ -1,0 +1,76 @@
+package io.github.yuokada;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Resolves version and runtime metadata for CLI version output.
+ */
+public final class VersionMetadata {
+
+    /**
+     * Fallback value used when metadata is unavailable.
+     */
+    public static final String UNKNOWN = "unknown";
+
+    private VersionMetadata() {
+    }
+
+    /**
+     * Returns the application version.
+     *
+     * @return application version or {@link #UNKNOWN}
+     */
+    public static String applicationVersion() {
+        try {
+            return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.application.version", String.class)
+                .filter(value -> !value.isBlank())
+                .orElse(UNKNOWN);
+        } catch (RuntimeException ignored) {
+            return UNKNOWN;
+        }
+    }
+
+    /**
+     * Loads git metadata written at build time.
+     *
+     * @return git properties, possibly empty
+     */
+    public static Properties gitProperties() {
+        Properties properties = new Properties();
+        try (InputStream input = VersionMetadata.class.getClassLoader()
+            .getResourceAsStream("git.properties")) {
+            if (input != null) {
+                properties.load(input);
+            }
+        } catch (IOException ignored) {
+            // Return an empty properties object when build metadata is unavailable.
+        }
+        return properties;
+    }
+
+    /**
+     * Reads a dependency version from Maven pom.properties on the classpath.
+     *
+     * @param groupId    dependency group ID
+     * @param artifactId dependency artifact ID
+     * @return dependency version or {@link #UNKNOWN}
+     */
+    public static String dependencyVersion(String groupId, String artifactId) {
+        String resourcePath = String.format("META-INF/maven/%s/%s/pom.properties", groupId, artifactId);
+        Properties properties = new Properties();
+        try (InputStream input = VersionMetadata.class.getClassLoader()
+            .getResourceAsStream(resourcePath)) {
+            if (input == null) {
+                return UNKNOWN;
+            }
+            properties.load(input);
+            return properties.getProperty("version", UNKNOWN);
+        } catch (IOException ignored) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/io/github/yuokada/core/LintFinding.java
+++ b/src/main/java/io/github/yuokada/core/LintFinding.java
@@ -18,6 +18,12 @@ import io.github.yuokada.core.util.JsonUtil;
 public final class LintFinding {
 
     /**
+     * Supplemental rule guidance bundled with a finding.
+     */
+    private record Guidance(String hint, String fix) {
+    }
+
+    /**
      * Severity levels for lint findings.
      */
     public enum Severity {
@@ -41,6 +47,12 @@ public final class LintFinding {
     /** Human-readable description of the finding. */
     private final String message;
 
+    /** Short explanation of why the rule matters. */
+    private final String hint;
+
+    /** Concrete suggestion for remediating the finding. */
+    private final String fix;
+
     /**
      * Constructs a new {@code LintFinding}.
      *
@@ -49,9 +61,29 @@ public final class LintFinding {
      * @param message  human-readable message
      */
     public LintFinding(String ruleId, Severity severity, String message) {
+        Guidance guidance = guidanceFor(ruleId);
         this.ruleId = ruleId;
         this.severity = severity;
         this.message = message;
+        this.hint = guidance.hint();
+        this.fix = guidance.fix();
+    }
+
+    /**
+     * Constructs a new {@code LintFinding} with explicit help content.
+     *
+     * @param ruleId   short rule identifier
+     * @param severity severity level
+     * @param message  human-readable message
+     * @param hint     short explanation of why the rule matters
+     * @param fix      actionable suggestion
+     */
+    public LintFinding(String ruleId, Severity severity, String message, String hint, String fix) {
+        this.ruleId = ruleId;
+        this.severity = severity;
+        this.message = message;
+        this.hint = hint;
+        this.fix = fix;
     }
 
     /**
@@ -82,6 +114,24 @@ public final class LintFinding {
     }
 
     /**
+     * Returns the short explanation of why the rule matters.
+     *
+     * @return hint string
+     */
+    public String getHint() {
+        return this.hint;
+    }
+
+    /**
+     * Returns the actionable suggestion for fixing the issue.
+     *
+     * @return fix string
+     */
+    public String getFix() {
+        return this.fix;
+    }
+
+    /**
      * Serialises this finding to a compact JSON object string.
      *
      * @return JSON representation, e.g. {@code {"ruleId":"W001","severity":"WARNING","message":"…"}}
@@ -90,12 +140,47 @@ public final class LintFinding {
         return "{"
             + "\"ruleId\":\"" + JsonUtil.escape(this.ruleId) + "\","
             + "\"severity\":\"" + this.severity.name() + "\","
-            + "\"message\":\"" + JsonUtil.escape(this.message) + "\""
+            + "\"message\":\"" + JsonUtil.escape(this.message) + "\","
+            + "\"hint\":\"" + JsonUtil.escape(this.hint) + "\","
+            + "\"fix\":\"" + JsonUtil.escape(this.fix) + "\""
             + "}";
     }
 
     @Override
     public String toString() {
         return "[" + this.severity.name() + "] " + this.ruleId + ": " + this.message;
+    }
+
+    private static Guidance guidanceFor(String ruleId) {
+        return switch (ruleId) {
+            case "W001" -> new Guidance(
+                "SELECT * couples queries to the table schema; adding a column can break consumers.",
+                "List only the columns you need instead of using SELECT *.");
+            case "W002" -> new Guidance(
+                "The function may be a typo or an unregistered UDF.",
+                "Check the spelling or register the function via --udf-catalog.");
+            case "W003" -> new Guidance(
+                "Calling a function with the wrong number of arguments fails at runtime.",
+                "Update the call to match the declared function arity.");
+            case "W004" -> new Guidance(
+                "The Trino server reported a non-fatal issue that may indicate a problem.",
+                "Review the server message and verify that the query intent is correct.");
+            case "W005" -> new Guidance(
+                "Positional references break when selected columns are reordered.",
+                "Replace ORDER BY 1 style references with explicit column names.");
+            case "W006" -> new Guidance(
+                "Without ORDER BY, repeated executions may return rows in different order.",
+                "Add ORDER BY before LIMIT, or document that the order is intentionally non-deterministic.");
+            case "W007" -> new Guidance(
+                "Unqualified names resolve against the session default catalog, not explicit catalogs in the query.",
+                "Fully qualify table references as catalog.schema.table.");
+            case "E001" -> new Guidance(
+                "Omitting WHERE on DELETE removes every row permanently.",
+                "Add a WHERE clause; WHERE 1=0 is useful as a dry-run safety check.");
+            case "E002", "E003", "E004", "E005" -> new Guidance(
+                "The remote Trino server reported a hard validation error.",
+                "Review the server message to identify the missing or incompatible object.");
+            default -> new Guidance("See the message text for details.", "Review the statement and retry.");
+        };
     }
 }

--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -14,6 +14,7 @@ import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.output.TextAnalysisPrinter;
 import io.github.yuokada.subcommand.util.SqlInput;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -159,6 +160,11 @@ public class Analyze implements Callable<Integer> {
             return ExitCodes.ERROR;
         }
 
+        Integer validationResult = validateOptions();
+        if (validationResult != null) {
+            return validationResult;
+        }
+
         List<String> statements = collectStatements();
         if (statements.size() > 1) {
             System.err.println(MULTIPLE_STATEMENTS_ERROR_MESSAGE);
@@ -198,6 +204,42 @@ public class Analyze implements Callable<Integer> {
             printer.printStatement(result, null, statement);
         }
         return ExitCode.OK;
+    }
+
+    private Integer validateOptions() {
+        if (!this.sqlFile.isEmpty()) {
+            Path sqlPath = Path.of(this.sqlFile);
+            if (!Files.exists(sqlPath)) {
+                System.err.println("Error: SQL file not found: " + this.sqlFile);
+                return ExitCodes.ERROR;
+            }
+            if (stdinHasData()) {
+                System.err.println("Error: provide either <file> or stdin, not both.");
+                return ExitCodes.ERROR;
+            }
+        }
+        if (this.udfCatalogPath != null && !this.udfCatalogPath.isBlank()) {
+            Path udfPath = Path.of(this.udfCatalogPath);
+            if (!Files.exists(udfPath)) {
+                System.err.println("Error: UDF catalog file not found: " + this.udfCatalogPath);
+                return ExitCodes.ERROR;
+            }
+            if (!this.validateFunctions) {
+                System.err.println(
+                    "Info: --udf-catalog implies function existence checking; pass "
+                        + "--validate-functions to also enable W002.");
+            }
+        }
+        if (isJsonFormat() && isBasicDetails()) {
+            System.err.println(
+                "Warning: --details basic suppresses extended fields; use --details full for complete JSON.");
+        }
+        if (this.serverOptions != null && this.serverOptions.isEnabled() && !isJsonFormat()
+            && !isFullDetails()) {
+            System.err.println(
+                "Warning: remote findings are only shown in --details full mode for text output.");
+        }
+        return null;
     }
 
     /**
@@ -287,6 +329,15 @@ public class Analyze implements Callable<Integer> {
      */
     private boolean isFullDetails() {
         return "full".equalsIgnoreCase(details);
+    }
+
+    private static boolean stdinHasData() {
+        try {
+            InputStream in = System.in;
+            return in != null && in.available() > 0;
+        } catch (IOException ignored) {
+            return false;
+        }
     }
 
     // Package-private setters to support testing without reflection.

--- a/src/main/java/io/github/yuokada/subcommand/Format.java
+++ b/src/main/java/io/github/yuokada/subcommand/Format.java
@@ -14,6 +14,9 @@ import io.github.yuokada.subcommand.util.SqlInput;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Statement;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -98,6 +101,11 @@ public class Format implements Callable<Integer> {
     public Integer call() throws IOException {
         boolean isStdin = this.sqlFile.isEmpty() || this.sqlFile.equals("-");
 
+        Integer validationResult = validateOptions(isStdin);
+        if (validationResult != null) {
+            return validationResult;
+        }
+
         KeywordCase kc;
         try {
             kc = KeywordCase.fromString(this.keywordCase);
@@ -151,6 +159,21 @@ public class Format implements Callable<Integer> {
             }
         }
         return ExitCodes.OK;
+    }
+
+    private Integer validateOptions(boolean isStdin) {
+        if (!isStdin) {
+            Path sqlPath = Path.of(this.sqlFile);
+            if (!Files.exists(sqlPath)) {
+                System.err.println("Error: SQL file not found: " + this.sqlFile);
+                return ExitCodes.ERROR;
+            }
+            if (stdinHasData()) {
+                System.err.println("Error: provide either <file> or stdin, not both.");
+                return ExitCodes.ERROR;
+            }
+        }
+        return null;
     }
 
     /**
@@ -324,6 +347,15 @@ public class Format implements Callable<Integer> {
      */
     private boolean isQuiet() {
         return this.entryCommand != null && this.entryCommand.isQuiet();
+    }
+
+    private static boolean stdinHasData() {
+        try {
+            InputStream in = System.in;
+            return in != null && in.available() > 0;
+        } catch (IOException ignored) {
+            return false;
+        }
     }
 
     // Package-private setters to support testing without reflection.

--- a/src/main/java/io/github/yuokada/subcommand/GenerateCompletion.java
+++ b/src/main/java/io/github/yuokada/subcommand/GenerateCompletion.java
@@ -1,0 +1,94 @@
+package io.github.yuokada.subcommand;
+
+import io.github.yuokada.EntryCommand;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import picocli.AutoComplete;
+import picocli.CommandLine;
+import picocli.CommandLine.Spec;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Generates shell completion scripts for the CLI.
+ */
+@CommandLine.Command(
+    name = "generate-completion",
+    description = "Generate shell completion scripts.")
+public class GenerateCompletion implements Callable<Integer> {
+
+    /**
+     * Shell type to generate.
+     */
+    @CommandLine.Option(names = {"--shell"}, defaultValue = "bash",
+        description = "Shell type: bash, zsh, or fish.")
+    private String shell;
+
+    /**
+     * Command specification for accessing the root command.
+     */
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        String shellName = this.shell.toLowerCase(Locale.ROOT);
+        return switch (shellName) {
+            case "bash", "zsh" -> printBashCompatibleScript();
+            case "fish" -> printFishScript();
+            default -> throw new CommandLine.ParameterException(spec.commandLine(),
+                "Unsupported shell: " + this.shell + " (expected: bash, zsh, fish)");
+        };
+    }
+
+    private int printBashCompatibleScript() {
+        CommandLine root = EntryCommand.newCommandLine();
+        String script = AutoComplete.bash(spec.root().name(), root);
+        spec.commandLine().getOut().print(script);
+        spec.commandLine().getOut().print('\n');
+        spec.commandLine().getOut().flush();
+        return 0;
+    }
+
+    private int printFishScript() {
+        String rootName = spec.root().name();
+        String script = """
+            complete -c %s -f
+            complete -c %s -n '__fish_use_subcommand' -a format -d 'Format SQL query'
+            complete -c %s -n '__fish_use_subcommand' -a analyze -d 'Analyze SQL query'
+            complete -c %s -n '__fish_use_subcommand' -a generate-completion -d 'Generate shell completion scripts'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l output -s o -r -d 'Write output to this file instead of stdout'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l check -d 'Check if input is already formatted'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l diff -d 'Show unified diff of formatting changes'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l keyword-case -r -a 'upper lower keep' -d 'SQL keyword case'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l indent-size -r -d 'Spaces per indentation level'
+            complete -c %s -n '__fish_seen_subcommand_from format' -l max-line-length -r -d 'Warn when formatted lines exceed this length'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l format -r -a 'text json' -d 'Output format'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l details -r -a 'basic full' -d 'Detail level'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l output -r -d 'Write output to the specified file path'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l show-ast -d 'Show AST for each statement'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l ast-view -r -a 'tree outline raw' -d 'AST display mode'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l ast-depth -r -d 'Maximum AST depth to display'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l ast-limit -r -d 'Maximum characters for embedded AST in JSON output'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l catalog -r -d 'Default catalog'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l schema -r -d 'Default schema'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l validate-functions -d 'Flag unknown functions as W002'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l known-functions -r -d 'Extra known function names'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l udf-catalog -r -d 'YAML file with UDF definitions'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server -r -d 'Trino server for remote validation'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server-user -r -d 'User name for the Trino session'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server-password -r -d 'Password for Basic auth'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server-access-token -r -d 'Bearer token for OAuth2 or JWT'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server-ssl -d 'Enable TLS for the Trino connection'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l server-ssl-trust-all -d 'Disable TLS certificate verification'
+            complete -c %s -n '__fish_seen_subcommand_from analyze' -l explain-timeout -r -d 'Timeout in seconds for remote validation'
+            complete -c %s -n '__fish_seen_subcommand_from generate-completion' -l shell -r -a 'bash zsh fish' -d 'Shell type'
+            """.formatted(
+            rootName, rootName, rootName, rootName, rootName, rootName, rootName, rootName,
+            rootName, rootName, rootName, rootName, rootName, rootName, rootName, rootName,
+            rootName, rootName, rootName, rootName, rootName, rootName, rootName, rootName,
+            rootName, rootName, rootName, rootName, rootName, rootName, rootName, rootName);
+        spec.commandLine().getOut().print(script);
+        spec.commandLine().getOut().flush();
+        return 0;
+    }
+}

--- a/src/main/java/io/github/yuokada/subcommand/output/TextAnalysisPrinter.java
+++ b/src/main/java/io/github/yuokada/subcommand/output/TextAnalysisPrinter.java
@@ -124,6 +124,8 @@ public final class TextAnalysisPrinter implements AnalysisPrinter {
         if (!findings.isEmpty()) {
             for (LintFinding f : findings) {
                 emitter.emit("Lint: " + f.toString());
+                emitter.emit("  Why: " + f.getHint());
+                emitter.emit("  Fix: " + f.getFix());
             }
         }
         if (r.getParseError() != null) {

--- a/src/test/java/io/github/yuokada/EntryCommandTest.java
+++ b/src/test/java/io/github/yuokada/EntryCommandTest.java
@@ -68,22 +68,35 @@ class EntryCommandTest {
 
     @Test
     void helpFlag_printsUsage() {
-        int exit = new CommandLine(new EntryCommand()).execute("--help");
-        String out = outContent.toString();
+        int exit = EntryCommand.newCommandLine().execute("--help");
+        String out = outContent.toString() + errContent.toString();
         // Usage text contains subcommands and description
         org.junit.jupiter.api.Assertions.assertTrue(out.contains("Usage:"));
         org.junit.jupiter.api.Assertions.assertTrue(out.contains("format"));
         org.junit.jupiter.api.Assertions.assertTrue(out.contains("analyze"));
-        org.junit.jupiter.api.Assertions.assertEquals(0, exit);
+        org.junit.jupiter.api.Assertions.assertEquals(2, exit);
     }
 
     @Test
     void versionFlag_printsVersion() {
-        int exit = new CommandLine(new EntryCommand()).execute("-V");
+        int exit = EntryCommand.newCommandLine().execute("-V");
         String out = outContent.toString();
         org.junit.jupiter.api.Assertions.assertTrue(out.contains("trino-query-formatter"));
-        org.junit.jupiter.api.Assertions.assertTrue(out.contains("("));
-        org.junit.jupiter.api.Assertions.assertTrue(out.contains(")"));
+        org.junit.jupiter.api.Assertions.assertFalse(out.contains("Git commit"));
+        org.junit.jupiter.api.Assertions.assertFalse(out.contains("("));
+        org.junit.jupiter.api.Assertions.assertEquals(0, exit);
+    }
+
+    @Test
+    void versionVerbose_printsExtendedMetadata() {
+        int exit = EntryCommand.newCommandLine().execute("-V", "--verbose");
+        String out = outContent.toString();
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("Git commit"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("Build date"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("Java runtime"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("Quarkus"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("trino-parser"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("trino-cli"));
         org.junit.jupiter.api.Assertions.assertEquals(0, exit);
     }
 

--- a/src/test/java/io/github/yuokada/core/LintFindingTest.java
+++ b/src/test/java/io/github/yuokada/core/LintFindingTest.java
@@ -1,0 +1,22 @@
+package io.github.yuokada.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LintFindingTest {
+
+    @Test
+    void everyKnownRuleHasHintAndFix() {
+        List<String> ruleIds = List.of(
+            "W001", "W002", "W003", "W004", "W005", "W006", "W007",
+            "E001", "E002", "E003", "E004", "E005");
+
+        for (String ruleId : ruleIds) {
+            LintFinding finding = new LintFinding(ruleId, LintFinding.Severity.WARNING, "message");
+            assertFalse(finding.getHint().isBlank(), "hint should be populated for " + ruleId);
+            assertFalse(finding.getFix().isBlank(), "fix should be populated for " + ruleId);
+        }
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeIssueValidationTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeIssueValidationTest.java
@@ -1,0 +1,121 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AnalyzeIssueValidationTest {
+
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalErr = System.err;
+    private final java.io.InputStream originalIn = System.in;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setErr(originalErr);
+        System.setIn(originalIn);
+    }
+
+    @Test
+    void jsonBasicWarnsAboutSuppressedFields(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Files.writeString(sqlFile, "SELECT * FROM foo;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sqlFile.toString());
+        analyze.setFormat("json");
+        analyze.setDetails("basic");
+
+        assertEquals(0, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("--details basic suppresses extended fields"));
+    }
+
+    @Test
+    void udfCatalogWithoutValidateFunctionsPrintsInfo(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Path udfFile = tempDir.resolve("udf.yml");
+        Files.writeString(sqlFile, "SELECT my_fn(a) FROM foo;");
+        Files.writeString(udfFile, "functions:\n  - name: my_fn\n    arity: 1\n");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sqlFile.toString());
+        analyze.setUdfCatalogPath(udfFile.toString());
+
+        assertEquals(0, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("--udf-catalog implies function existence checking"));
+    }
+
+    @Test
+    void textBasicWithRemoteValidationPrintsWarning(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Files.writeString(sqlFile, "SELECT id FROM foo;");
+
+        TrinoConnectionOptions options = new TrinoConnectionOptions();
+        options.setServer("localhost:8080");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sqlFile.toString());
+        analyze.setFormat("text");
+        analyze.setDetails("basic");
+        analyze.setServerOptions(options);
+
+        assertEquals(0, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("remote findings are only shown in --details full mode"));
+    }
+
+    @Test
+    void missingSqlFileReturnsError() throws IOException {
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile("missing.sql");
+
+        assertEquals(2, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8).contains("SQL file not found"));
+    }
+
+    @Test
+    void missingUdfCatalogReturnsError(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Files.writeString(sqlFile, "SELECT id FROM foo;");
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sqlFile.toString());
+        analyze.setUdfCatalogPath(tempDir.resolve("missing.yml").toString());
+
+        assertEquals(2, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("UDF catalog file not found"));
+    }
+
+    @Test
+    void fileAndStdinTogetherReturnError(@TempDir Path tempDir) throws IOException {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Files.writeString(sqlFile, "SELECT id FROM foo;");
+        System.setIn(new ByteArrayInputStream("SELECT 1;".getBytes(StandardCharsets.UTF_8)));
+
+        Analyze analyze = new Analyze();
+        analyze.setSqlFile(sqlFile.toString());
+
+        assertEquals(2, analyze.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("provide either <file> or stdin, not both"));
+    }
+}

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeJsonFullExtendedTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeJsonFullExtendedTest.java
@@ -65,6 +65,8 @@ class AnalyzeJsonFullExtendedTest {
         assertTrue(out.contains("\"findings\""), "findings key should be in JSON: " + out);
         assertTrue(out.contains("\"W001\""), "W001 rule ID should be in JSON: " + out);
         assertTrue(out.contains("\"WARNING\""), "WARNING severity should be in JSON: " + out);
+        assertTrue(out.contains("\"hint\""), "hint field should be in JSON: " + out);
+        assertTrue(out.contains("\"fix\""), "fix field should be in JSON: " + out);
     }
 
     @Test
@@ -99,4 +101,3 @@ class AnalyzeJsonFullExtendedTest {
         assertTrue(out.contains("\"findings\":[]"), "Empty findings array should be in JSON: " + out);
     }
 }
-

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsExtendedTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsExtendedTest.java
@@ -37,6 +37,7 @@ class AnalyzeTextDetailsExtendedTest {
             WITH a AS (SELECT 1 AS id)
             SELECT LOWER(CAST(a.id AS VARCHAR)), COUNT(*) AS c, ROW_NUMBER() OVER(PARTITION BY a.id)
             FROM a JOIN catalog2.s.t2 ON 1=1
+            ORDER BY 1
             ;
             """;
         Files.writeString(sqlFile, sql);

--- a/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsExtendedTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/AnalyzeTextDetailsExtendedTest.java
@@ -54,5 +54,7 @@ class AnalyzeTextDetailsExtendedTest {
         assertTrue(out.toLowerCase().contains("scalar=[lower]"));
         assertTrue(out.toLowerCase().contains("aggregate=[count]"));
         assertTrue(out.toLowerCase().contains("window=[row_number]"));
+        assertTrue(out.contains("  Why: "));
+        assertTrue(out.contains("  Fix: "));
     }
 }

--- a/src/test/java/io/github/yuokada/subcommand/FormatIssueValidationTest.java
+++ b/src/test/java/io/github/yuokada/subcommand/FormatIssueValidationTest.java
@@ -1,0 +1,56 @@
+package io.github.yuokada.subcommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FormatIssueValidationTest {
+
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalErr = System.err;
+    private final java.io.InputStream originalIn = System.in;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setErr(originalErr);
+        System.setIn(originalIn);
+    }
+
+    @Test
+    void missingSqlFileReturnsError() throws Exception {
+        Format format = new Format();
+        format.setSqlFile("missing.sql");
+
+        assertEquals(2, format.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8).contains("SQL file not found"));
+    }
+
+    @Test
+    void fileAndStdinTogetherReturnError(@TempDir Path tempDir) throws Exception {
+        Path sqlFile = tempDir.resolve("test.sql");
+        Files.writeString(sqlFile, "select id from foo;");
+        System.setIn(new ByteArrayInputStream("select 1;".getBytes(StandardCharsets.UTF_8)));
+
+        Format format = new Format();
+        format.setSqlFile(sqlFile.toString());
+
+        assertEquals(2, format.call());
+        assertTrue(errContent.toString(StandardCharsets.UTF_8)
+            .contains("provide either <file> or stdin, not both"));
+    }
+}


### PR DESCRIPTION
## 概要
Phase A の CLI 改善をまとめて実装します。

## 変更内容
- lint finding に `hint` / `fix` を追加し、`--details full` の text/json 出力で参照できるようにした
- `analyze` / `format` にオプション検証を追加し、ファイル未存在や stdin 併用時のエラーメッセージを改善した
- `--version --verbose` で Git commit、build date、Java runtime、Quarkus、trino-parser、trino-cli を表示できるようにした
- `generate-completion` サブコマンドと `completions/` 配下のサンプルを追加した
- README に version verbose、shell completion、lint 詳細表示、オプション検証メッセージの説明を追加した
- 関連ユニットテストを追加・更新した

## 確認
- `./mvnw -q -Dtest=EntryCommandTest,AnalyzeIssueValidationTest,FormatIssueValidationTest,LintFindingTest test`
- `./mvnw test`
