### PR TITLE
Extract shared directory command utilities

### DIFF
--- a/src/main/java/io/github/yuokada/subcommand/Analyze.java
+++ b/src/main/java/io/github/yuokada/subcommand/Analyze.java
@@ -19,14 +19,14 @@ import io.github.yuokada.subcommand.output.AnalysisPrinter;
 import io.github.yuokada.subcommand.output.JsonAnalysisPrinter;
 import io.github.yuokada.subcommand.output.OutputEmitter;
 import io.github.yuokada.subcommand.output.TextAnalysisPrinter;
+import io.github.yuokada.subcommand.util.DirectoryProcessor;
 import io.github.yuokada.subcommand.util.SqlFileCollector;
 import io.github.yuokada.subcommand.util.SqlInput;
+import io.github.yuokada.subcommand.util.StdinDetector;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -34,10 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
@@ -454,39 +450,12 @@ public class Analyze implements Callable<Integer> {
     private void processDirectoryFiles(Path baseDir, List<Path> files, Set<String> effectiveKnown,
         Map<String, UdfDefinition> udfCatalog, DirectoryAnalysisConsumer consumer)
         throws IOException {
-        int parallelism = directoryParallelism(files.size());
-        if (parallelism <= 1) {
-            for (Path file : files) {
-                consumer.accept(analyzeDirectoryFile(baseDir, file, effectiveKnown, udfCatalog));
-            }
-            return;
-        }
-
-        ForkJoinPool pool = new ForkJoinPool(parallelism);
-        try {
-            ArrayDeque<Future<DirectoryAnalysis>> pending = new ArrayDeque<>();
-            int nextFile = 0;
-            while (nextFile < files.size() && pending.size() < parallelism) {
-                Path file = files.get(nextFile++);
-                pending.add(pool.submit(
-                    () -> analyzeDirectoryFile(baseDir, file, effectiveKnown, udfCatalog)));
-            }
-            while (!pending.isEmpty()) {
-                consumer.accept(pending.remove().get());
-                if (nextFile < files.size()) {
-                    Path file = files.get(nextFile++);
-                    pending.add(pool.submit(
-                        () -> analyzeDirectoryFile(baseDir, file, effectiveKnown, udfCatalog)));
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Parallel directory analysis interrupted", e);
-        } catch (ExecutionException e) {
-            throw new IOException("Parallel directory analysis failed", e.getCause());
-        } finally {
-            pool.shutdown();
-        }
+        DirectoryProcessor.processOrdered(
+            files,
+            DirectoryProcessor.parallelism(files.size(), this.directoryParallelismOverride),
+            file -> analyzeDirectoryFile(baseDir, file, effectiveKnown, udfCatalog),
+            consumer::accept,
+            "Parallel directory analysis");
     }
 
     private String limitAst(String ast) {
@@ -687,40 +656,8 @@ public class Analyze implements Callable<Integer> {
         return "full".equalsIgnoreCase(details);
     }
 
-    private int directoryParallelism(int fileCount) {
-        if (fileCount <= 1) {
-            return fileCount;
-        }
-        int processors = this.directoryParallelismOverride == null
-            ? Runtime.getRuntime().availableProcessors()
-            : this.directoryParallelismOverride;
-        return Math.min(fileCount, Math.max(1, processors));
-    }
-
     private static boolean stdinHasData() {
-        InputStream in = System.in;
-        if (in == null) {
-            return false;
-        }
-        // available() can block in some environments (e.g. Maven Surefire where System.in
-        // is socket-backed). Run the check in a daemon thread with a short timeout to
-        // keep this non-blocking in all contexts.
-        AtomicBoolean hasData = new AtomicBoolean(false);
-        Thread checker = new Thread(() -> {
-            try {
-                hasData.set(in.available() > 0);
-            } catch (IOException ignored) {
-                // leave as false
-            }
-        }, "stdin-checker");
-        checker.setDaemon(true);
-        checker.start();
-        try {
-            checker.join(50L);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        return hasData.get();
+        return StdinDetector.hasData();
     }
 
     private void applyConfigDefaults() throws ConfigException {

--- a/src/main/java/io/github/yuokada/subcommand/Format.java
+++ b/src/main/java/io/github/yuokada/subcommand/Format.java
@@ -13,23 +13,19 @@ import io.github.yuokada.core.KeywordCaseTransformer;
 import io.github.yuokada.core.UnifiedDiff;
 import io.github.yuokada.core.KeywordCaseTransformer.KeywordCase;
 import io.github.yuokada.subcommand.output.OutputEmitter;
+import io.github.yuokada.subcommand.util.DirectoryProcessor;
 import io.github.yuokada.subcommand.util.SqlFileCollector;
 import io.github.yuokada.subcommand.util.SqlInput;
+import io.github.yuokada.subcommand.util.StdinDetector;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Statement;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
@@ -354,37 +350,12 @@ public class Format implements Callable<Integer> {
 
     private void processDirectoryFiles(Path baseDir, List<Path> files, KeywordCase kc,
         Consumer<DirectoryFormatResult> consumer) throws IOException {
-        int parallelism = directoryParallelism(files.size());
-        if (parallelism <= 1) {
-            for (Path file : files) {
-                consumer.accept(formatDirectoryFile(baseDir, file, kc));
-            }
-            return;
-        }
-
-        ForkJoinPool pool = new ForkJoinPool(parallelism);
-        try {
-            ArrayDeque<Future<DirectoryFormatResult>> pending = new ArrayDeque<>();
-            int nextFile = 0;
-            while (nextFile < files.size() && pending.size() < parallelism) {
-                Path file = files.get(nextFile++);
-                pending.add(pool.submit(() -> formatDirectoryFile(baseDir, file, kc)));
-            }
-            while (!pending.isEmpty()) {
-                consumer.accept(pending.remove().get());
-                if (nextFile < files.size()) {
-                    Path file = files.get(nextFile++);
-                    pending.add(pool.submit(() -> formatDirectoryFile(baseDir, file, kc)));
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Parallel directory formatting interrupted", e);
-        } catch (ExecutionException e) {
-            throw new IOException("Parallel directory formatting failed", e.getCause());
-        } finally {
-            pool.shutdown();
-        }
+        DirectoryProcessor.processOrdered(
+            files,
+            DirectoryProcessor.parallelism(files.size(), this.directoryParallelismOverride),
+            file -> formatDirectoryFile(baseDir, file, kc),
+            consumer::accept,
+            "Parallel directory formatting");
     }
 
     private DirectoryFormatResult formatDirectoryFile(Path baseDir, Path file, KeywordCase kc) {
@@ -557,40 +528,8 @@ public class Format implements Callable<Integer> {
         return this.entryCommand != null && this.entryCommand.isQuiet();
     }
 
-    private int directoryParallelism(int fileCount) {
-        if (fileCount <= 1) {
-            return fileCount;
-        }
-        int processors = this.directoryParallelismOverride == null
-            ? Runtime.getRuntime().availableProcessors()
-            : this.directoryParallelismOverride;
-        return Math.min(fileCount, Math.max(1, processors));
-    }
-
     private static boolean stdinHasData() {
-        InputStream in = System.in;
-        if (in == null) {
-            return false;
-        }
-        // available() can block in some environments (e.g. Maven Surefire where System.in
-        // is socket-backed). Run the check in a daemon thread with a short timeout to
-        // keep this non-blocking in all contexts.
-        AtomicBoolean hasData = new AtomicBoolean(false);
-        Thread checker = new Thread(() -> {
-            try {
-                hasData.set(in.available() > 0);
-            } catch (IOException ignored) {
-                // leave as false
-            }
-        }, "stdin-checker");
-        checker.setDaemon(true);
-        checker.start();
-        try {
-            checker.join(50L);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        return hasData.get();
+        return StdinDetector.hasData();
     }
 
     private void applyConfigDefaults() throws ConfigException {

--- a/src/main/java/io/github/yuokada/subcommand/util/DirectoryProcessor.java
+++ b/src/main/java/io/github/yuokada/subcommand/util/DirectoryProcessor.java
@@ -1,0 +1,117 @@
+package io.github.yuokada.subcommand.util;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
+/**
+ * Utility for processing directory entries in parallel while preserving input order.
+ */
+public final class DirectoryProcessor {
+
+    private DirectoryProcessor() {
+    }
+
+    /**
+     * Processes items with bounded parallelism and emits results in the same order as inputs.
+     *
+     * @param items input items to process
+     * @param parallelism requested parallelism; values below 1 are treated as 1
+     * @param task processor called for each item
+     * @param consumer ordered result consumer
+     * @param failureMessage message used when parallel execution fails
+     * @param <T> input item type
+     * @param <R> result type
+     * @throws IOException when processing is interrupted or a task fails
+     */
+    public static <T, R> void processOrdered(
+        List<T> items,
+        int parallelism,
+        ThrowingFunction<T, R> task,
+        ThrowingConsumer<R> consumer,
+        String failureMessage) throws IOException {
+        int effectiveParallelism = Math.min(items.size(), Math.max(1, parallelism));
+        if (effectiveParallelism <= 1) {
+            for (T item : items) {
+                consumer.accept(task.apply(item));
+            }
+            return;
+        }
+
+        ForkJoinPool pool = new ForkJoinPool(effectiveParallelism);
+        try {
+            ArrayDeque<Future<R>> pending = new ArrayDeque<>();
+            int nextItem = 0;
+            while (nextItem < items.size() && pending.size() < effectiveParallelism) {
+                T item = items.get(nextItem++);
+                pending.add(pool.submit(() -> task.apply(item)));
+            }
+            while (!pending.isEmpty()) {
+                consumer.accept(pending.remove().get());
+                if (nextItem < items.size()) {
+                    T item = items.get(nextItem++);
+                    pending.add(pool.submit(() -> task.apply(item)));
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(failureMessage + " interrupted", e);
+        } catch (ExecutionException e) {
+            throw new IOException(failureMessage + " failed", e.getCause());
+        } finally {
+            pool.shutdown();
+        }
+    }
+
+    /**
+     * Calculates effective parallelism for a directory workload.
+     *
+     * @param itemCount number of input items
+     * @param override optional override, usually provided by tests
+     * @return effective parallelism capped by item count and at least 1 when items exist
+     */
+    public static int parallelism(int itemCount, Integer override) {
+        if (itemCount <= 1) {
+            return itemCount;
+        }
+        int processors = override == null ? Runtime.getRuntime().availableProcessors() : override;
+        return Math.min(itemCount, Math.max(1, processors));
+    }
+
+    /**
+     * Function variant that can throw {@link IOException}.
+     *
+     * @param <T> input type
+     * @param <R> result type
+     */
+    @FunctionalInterface
+    public interface ThrowingFunction<T, R> {
+        /**
+         * Applies this function.
+         *
+         * @param input input value
+         * @return function result
+         * @throws IOException when processing fails
+         */
+        R apply(T input) throws IOException;
+    }
+
+    /**
+     * Consumer variant that can throw {@link IOException}.
+     *
+     * @param <T> input type
+     */
+    @FunctionalInterface
+    public interface ThrowingConsumer<T> {
+        /**
+         * Consumes a value.
+         *
+         * @param input input value
+         * @throws IOException when consuming fails
+         */
+        void accept(T input) throws IOException;
+    }
+}

--- a/src/main/java/io/github/yuokada/subcommand/util/StdinDetector.java
+++ b/src/main/java/io/github/yuokada/subcommand/util/StdinDetector.java
@@ -1,0 +1,47 @@
+package io.github.yuokada.subcommand.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Utility for checking stdin availability without blocking command execution.
+ */
+public final class StdinDetector {
+
+    private static final long CHECK_TIMEOUT_MILLIS = 50L;
+
+    private StdinDetector() {
+    }
+
+    /**
+     * Returns true when stdin appears to have buffered data.
+     *
+     * @return true when data is available on stdin
+     */
+    public static boolean hasData() {
+        InputStream in = System.in;
+        if (in == null) {
+            return false;
+        }
+        // available() can block in some environments (e.g. Maven Surefire where System.in
+        // is socket-backed). Run the check in a daemon thread with a short timeout to
+        // keep this non-blocking in all contexts.
+        AtomicBoolean hasData = new AtomicBoolean(false);
+        Thread checker = new Thread(() -> {
+            try {
+                hasData.set(in.available() > 0);
+            } catch (IOException ignored) {
+                // leave as false
+            }
+        }, "stdin-checker");
+        checker.setDaemon(true);
+        checker.start();
+        try {
+            checker.join(CHECK_TIMEOUT_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return hasData.get();
+    }
+}


### PR DESCRIPTION
## Summary
- Extract ordered parallel directory processing into DirectoryProcessor
- Extract non-blocking stdin detection into StdinDetector
- Reuse the shared utilities from format and analyze subcommands

## Tests
- ./mvnw -q validate
- ./mvnw -q -Dtest=FormatDirectoryModeTest,AnalyzeDirectoryModeTest test
- ./mvnw -q test